### PR TITLE
feat: v2 connector API contract with /generate and /models endpoints

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule ".woped-hooks"]
 	path = .woped-hooks
 	url = git@github.com:woped/woped-git-hooks.git
-	branch = python-hooks-only
+	branch = main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+        args: [-C, .woped-hooks/PythonHooks/.gitlint, --contrib=contrib-title-conventional-commits, --msg-filename]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.9
+    hooks:
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: check-branch-name-post-checkout
+        name: check branch name for compliance with GitHub Flow
+        entry: "bash -lc 'python3 .woped-hooks/PythonHooks/hooks/post-checkout.py \"$@\" || python .woped-hooks/PythonHooks/hooks/post-checkout.py \"$@\" || py -3 .woped-hooks/PythonHooks/hooks/post-checkout.py \"$@\"' ignore"
+        language: system
+        stages: [post-checkout]
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# llm-api-connector
+﻿# llm-api-connector
 
 This repository is for the source code handling the web-api call of llm providers as GPT from Open AI
 
@@ -44,7 +44,9 @@ export FLASK_DEBUG=1
 flask run
 ```
 
-This will start the Flask development server with auto-reloading enabled, and the application will be accessible at http://localhost:5000. 
+This will start the Flask development server with auto-reloading enabled, and the application will be accessible at http://localhost:5000.
+
+The interactive API documentation (Swagger UI) is available at http://localhost:5000/docs.
 
 > **Note:** In older versions of Flask, you might have used `FLASK_ENV=development`. However, since Flask 2.3 (and this project uses Flask 3.1+), `FLASK_ENV` has been removed. Setting `FLASK_DEBUG=1` is now the correct way to enable development mode.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# llm-api-connector
 
-This repository is for the source code handling the web-api call of llm providers as GPT from Open AI
+HTTP connector service that proxies process-description text to LLM providers (OpenAI, Google Gemini) and returns the raw model response. Consumed by the t2p-2.0 backend.
 
 ## Prerequisites
 
@@ -28,27 +28,36 @@ After cloning this repository, it's essential to [set up git hooks](https://gith
 
 ## Running the Application Locally
 
-To run the Flask application in development mode, make sure your `.venv` is activated and set the necessary environment variables:
+A `.flaskenv` file in the project root already sets `FLASK_APP` and the environment, so activating the venv and running `flask run` is enough:
 
-**Windows (PowerShell):**
-```powershell
-$env:FLASK_APP = "llm-api-connector.py"
-$env:FLASK_DEBUG = "1"
-flask run
-```
-
-**macOS/Linux:**
 ```bash
-export FLASK_APP=llm-api-connector.py
-export FLASK_DEBUG=1
 flask run
 ```
 
-This will start the Flask development server with auto-reloading enabled, and the application will be accessible at http://localhost:5000.
-
+The application will be accessible at http://localhost:5000.  
 The interactive API documentation (Swagger UI) is available at http://localhost:5000/docs.
 
-> **Note:** In older versions of Flask, you might have used `FLASK_ENV=development`. However, since Flask 2.3 (and this project uses Flask 3.1+), `FLASK_ENV` has been removed. Setting `FLASK_DEBUG=1` is now the correct way to enable development mode.
+> **Note:** `FLASK_ENV` is still used by this project's `config.py` to select the active configuration class (`development` / `production` / `testing`). It is separate from Flask's own debug flag and is already pre-configured in `.flaskenv` for local development — no manual export is needed.
+
+## Calling the API
+
+All requests to `/generate` require the provider API key as a Bearer token in the `Authorization` header — it is never part of the request body:
+
+```
+Authorization: Bearer <your-provider-api-key>
+```
+
+Example request body for `POST /generate`:
+```json
+{
+  "user_text": "A customer submits an order. A clerk checks the inventory ...",
+  "provider": "openai",
+  "model": "gpt-4o",
+  "prompting_strategy": "few_shot"
+}
+```
+
+Use `GET /models` to retrieve the list of supported provider/model pairs. See `docs/openapi.yaml` or the Swagger UI at `/docs` for the full API contract.
 
 ## Running the Application with Docker
 
@@ -64,9 +73,11 @@ docker run -p 5000:5000 llm-api-connector
 The application will be accessible at http://localhost:5000.
 
 ## Testing
-To test the code, navigate to the test folder and run the following command:
+
+Run the following commands from the **project root** (not the `tests` folder — the test suite needs to resolve the `app` package):
+
 ```bash
-coverage run -m unittest discover
+coverage run -m unittest discover -s tests
 ```
 You can then view the coverage report by running:
 ```bash

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,8 @@
-import click, unittest, sys, logging, time
+import click, unittest, sys, logging, time, os
 from config import get_config
-from flask import Flask, request, g
+from flask import Flask, request, g, send_from_directory
 from flask_wtf.csrf import CSRFProtect
+from flask_swagger_ui import get_swaggerui_blueprint
 
 # Logging konfigurieren
 logging.basicConfig(level=logging.INFO)
@@ -40,6 +41,22 @@ def create_app(config_class=None):
 
     app.register_blueprint(api_bp)
     logger.info("Blueprints registered")
+
+    # Swagger UI  — served at /docs, spec sourced from /openapi.yaml
+    SWAGGER_URL = "/docs"
+    SPEC_URL = "/openapi.yaml"
+    swaggerui_bp = get_swaggerui_blueprint(
+        SWAGGER_URL,
+        SPEC_URL,
+        config={"app_name": "LLM API Connector"},
+    )
+    app.register_blueprint(swaggerui_bp, url_prefix=SWAGGER_URL)
+
+    _docs_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "docs")
+
+    @app.route("/openapi.yaml")
+    def serve_openapi_yaml():
+        return send_from_directory(_docs_dir, "openapi.yaml")
 
     # Request logging
     @app.before_request

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,32 +7,37 @@ from flask_wtf.csrf import CSRFProtect
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 def create_app(config_class=None):
     """Application factory pattern"""
     app = Flask(__name__)
-    
+
     # Load configuration
     if config_class is None:
         config_class = get_config()
     app.config.from_object(config_class)
     try:
-        logger.info("Flask app created with config: %s", getattr(config_class, "__name__", str(config_class)))
+        logger.info(
+            "Flask app created with config: %s",
+            getattr(config_class, "__name__", str(config_class)),
+        )
         logger.debug(
             "Config flags: DEBUG=%s TESTING=%s WTF_CSRF_ENABLED=%s",
-            app.config.get('DEBUG'),
-            app.config.get('TESTING'),
-            app.config.get('WTF_CSRF_ENABLED', True),
+            app.config.get("DEBUG"),
+            app.config.get("TESTING"),
+            app.config.get("WTF_CSRF_ENABLED", True),
         )
     except Exception as e:
         logger.warning("Unable to log config details: %s", e)
-    
+
     # CSRF-Security
-    if app.config.get('WTF_CSRF_ENABLED', True):
+    if app.config.get("WTF_CSRF_ENABLED", True):
         csrf = CSRFProtect(app)
         logger.info("CSRF protection enabled")
 
     # Register blueprints
     from app.api import bp as api_bp
+
     app.register_blueprint(api_bp)
     logger.info("Blueprints registered")
 
@@ -46,7 +51,7 @@ def create_app(config_class=None):
     def _log_request_end(response):
         try:
             duration = None
-            if hasattr(g, '_start_time'):
+            if hasattr(g, "_start_time"):
                 duration = time.time() - g._start_time
             logger.info(
                 "%s %s <- %s in %.3fs",
@@ -65,17 +70,17 @@ def create_app(config_class=None):
         """Run the unit tests."""
         logger.info("Running unit tests...")
         loader = unittest.TestLoader()
-        start_dir = 'tests'
+        start_dir = "tests"
         suite = loader.discover(start_dir)
-        
+
         runner = unittest.TextTestRunner(verbosity=2)
         result = runner.run(suite)
-        
+
         if result.wasSuccessful():
             logger.info("All tests passed.")
             return 0
         else:
             logger.error("Some tests failed.")
             sys.exit(1)
-    
+
     return app

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
 
-bp = Blueprint('api', __name__)
+bp = Blueprint("api", __name__)
 
 from app.api import routes

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -2,8 +2,7 @@ import logging, time
 from app.api import bp
 from app.services.llm_service import LLMService
 from app.services import model_registry
-from config import get_config
-from flask import request, jsonify
+from flask import request, jsonify, current_app
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # Logging konfigurieren
@@ -17,6 +16,12 @@ REQUEST_COUNT = Counter(
 REQUEST_LATENCY = Histogram(
     "http_request_duration_seconds", "HTTP request latency", ["method", "endpoint"]
 )
+
+# Single, stateless LLMService instance shared across requests. Building it once
+# avoids re-reading and re-parsing the few-shot template file on every request
+# (the per-call provider clients are still created inside each call_* method,
+# keeping per-request API keys isolated).
+_llm_service = LLMService()
 
 
 # --- v2 contract API (consumed by t2p-2.0) --------------------------------
@@ -87,17 +92,15 @@ def generate():
                 f"Unknown provider/model: {provider}/{model}.",
             )
 
-        config_instance = get_config()()
-        llm_service = LLMService()
         logger.info(
             "Invoking LLMService.generate (provider=%s, model=%s)", provider, model
         )
-        raw_response = llm_service.generate(
+        raw_response = _llm_service.generate(
             api_key=api_key,
             provider=provider,
             model=model,
             user_text=data["user_text"],
-            system_prompt=config_instance.SYSTEM_PROMPT,
+            system_prompt=current_app.config["SYSTEM_PROMPT"],
             prompting_strategy=data.get("prompting_strategie", "few_shot"),
         )
         return jsonify({"raw_response": raw_response}), 200

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -101,7 +101,7 @@ def generate():
             model=model,
             user_text=data["user_text"],
             system_prompt=current_app.config["SYSTEM_PROMPT"],
-            prompting_strategy=data.get("prompting_strategie", "few_shot"),
+            prompting_strategy=data.get("prompting_strategy", "few_shot"),
         )
         return jsonify({"raw_response": raw_response}), 200
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,6 +1,7 @@
 import logging, time
 from app.api import bp
 from app.services.llm_service import LLMService
+from app.services import model_registry
 from config import get_config
 from flask import request, jsonify, Response
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
@@ -122,6 +123,120 @@ def call_gemini():
         return jsonify({"error": str(e)}), 500
     finally:
         REQUEST_LATENCY.labels(method="POST", endpoint="/call_gemini").observe(
+            time.time() - start_time
+        )
+
+
+# --- v2 contract API (consumed by t2p-2.0) --------------------------------
+#
+# t2p-2.0's ConnectorClient calls these two endpoints:
+#   POST <connector>/generate   body {user_text, provider, model}, Bearer auth
+#   GET  <connector>/models     -> {"models": [{provider, model, default}]}
+# The error body shape is {"error": {"code": str, "message": str}} so t2p-2.0
+# can relay 4xx client errors unchanged.
+
+
+def _v2_error(status_code, code, message):
+    """Build the standard connector error body and status tuple."""
+    return jsonify({"error": {"code": code, "message": message}}), status_code
+
+
+def _extract_bearer_key():
+    """Return the raw API key from a well-formed ``Authorization: Bearer <key>``.
+
+    Returns None if the header is missing or malformed.
+    """
+    auth = request.headers.get("Authorization", "")
+    parts = auth.split()
+    if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1]:
+        return parts[1]
+    return None
+
+
+@bp.route("/generate", methods=["POST"])
+def generate():
+    """Generate a structured BPMN-JSON process model from a description.
+
+    Provider/model are validated against the registry; the API key is taken
+    from the Authorization header (never from the body). Returns
+    ``{"raw_response": <string>}`` on success.
+    """
+    start_time = time.time()
+    status = "200"
+    try:
+        api_key = _extract_bearer_key()
+        if api_key is None:
+            status = "400"
+            return _v2_error(
+                400, "invalid_request", "Missing or malformed Authorization header."
+            )
+
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            status = "400"
+            return _v2_error(400, "invalid_request", "Request body must be JSON.")
+
+        missing = [f for f in ("user_text", "provider", "model") if not data.get(f)]
+        if missing:
+            status = "400"
+            return _v2_error(
+                400,
+                "invalid_request",
+                f"Missing or empty field(s): {', '.join(missing)}.",
+            )
+
+        provider = data["provider"]
+        model = data["model"]
+        if not model_registry.is_valid(provider, model):
+            status = "400"
+            return _v2_error(
+                400,
+                "invalid_provider",
+                f"Unknown provider/model: {provider}/{model}.",
+            )
+
+        config_instance = get_config()()
+        llm_service = LLMService()
+        logger.info(
+            "Invoking LLMService.generate (provider=%s, model=%s)", provider, model
+        )
+        raw_response = llm_service.generate(
+            api_key=api_key,
+            provider=provider,
+            model=model,
+            user_text=data["user_text"],
+            system_prompt=config_instance.SYSTEM_PROMPT,
+            prompting_strategy=data.get("prompting_strategie", "few_shot"),
+        )
+        return jsonify({"raw_response": raw_response}), 200
+
+    except Exception as e:
+        status = "500"
+        logger.exception("/generate failed: %s", e)
+        return _v2_error(
+            500, "upstream_error", "The LLM provider call failed."
+        )
+    finally:
+        REQUEST_COUNT.labels(method="POST", endpoint="/generate", status=status).inc()
+        REQUEST_LATENCY.labels(method="POST", endpoint="/generate").observe(
+            time.time() - start_time
+        )
+
+
+@bp.route("/models", methods=["GET"])
+def models():
+    """Return the advertised provider/model pairs from the registry."""
+    start_time = time.time()
+    status = "200"
+    try:
+        return jsonify({"models": model_registry.list_models()}), 200
+    except Exception as e:
+        status = "500"
+        logger.exception("/models failed: %s", e)
+        return _v2_error(500, "internal_error", "Could not list models.")
+    finally:
+        REQUEST_COUNT.labels(method="GET", endpoint="/models", status=status).inc()
+        REQUEST_LATENCY.labels(method="GET", endpoint="/models").observe(
             time.time() - start_time
         )
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,12 +10,16 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Prometheus Metriken
-REQUEST_COUNT = Counter('http_requests_total', 'Total HTTP requests', ['method', 'endpoint', 'status'])
-REQUEST_LATENCY = Histogram('http_request_duration_seconds', 'HTTP request latency', ['method', 'endpoint'])
-CALL_OPENAI_DURATION = Histogram('call_openai_duration_seconds', 'OpenAI call duration')
+REQUEST_COUNT = Counter(
+    "http_requests_total", "Total HTTP requests", ["method", "endpoint", "status"]
+)
+REQUEST_LATENCY = Histogram(
+    "http_request_duration_seconds", "HTTP request latency", ["method", "endpoint"]
+)
+CALL_OPENAI_DURATION = Histogram("call_openai_duration_seconds", "OpenAI call duration")
 
 
-@bp.route('/call_openai', methods=['POST'])
+@bp.route("/call_openai", methods=["POST"])
 def call_openai():
     """Call OpenAI GPT model"""
     start_time = time.time()
@@ -25,9 +29,9 @@ def call_openai():
         if data is None:
             logger.warning("/call_openai received no JSON body")
         else:
-            req_keys = [k for k in data.keys() if k != 'api_key']
-            user_text_len = len(data.get('user_text') or '')
-            prompting_strategy = data.get('prompting_strategie', 'few_shot')
+            req_keys = [k for k in data.keys() if k != "api_key"]
+            user_text_len = len(data.get("user_text") or "")
+            prompting_strategy = data.get("prompting_strategie", "few_shot")
             logger.debug(
                 "call_openai payload: keys=%s, user_text_len=%d, prompting_strategy=%s",
                 req_keys,
@@ -36,32 +40,40 @@ def call_openai():
             )
         config_class = get_config()
         config_instance = config_class()
-        
+
         llm_service = LLMService()
         logger.info("Invoking LLMService.call_openai")
         result = llm_service.call_openai(
-            api_key=data.get('api_key'),
-            system_prompt=data.get('system_prompt', config_instance.SYSTEM_PROMPT),
-            user_text=data.get('user_text'),
-            prompting_strategy=data.get('prompting_strategie', 'few_shot')
+            api_key=data.get("api_key"),
+            system_prompt=data.get("system_prompt", config_instance.SYSTEM_PROMPT),
+            user_text=data.get("user_text"),
+            prompting_strategy=data.get("prompting_strategie", "few_shot"),
         )
-        
-        REQUEST_COUNT.labels(method='POST', endpoint='/call_openai', status='200').inc()
+
+        REQUEST_COUNT.labels(method="POST", endpoint="/call_openai", status="200").inc()
         duration = time.time() - start_time
-        logger.info("/call_openai succeeded in %.3fs (response_len=%d)", duration, len(result or ''))
-        if request.args.get('format') == 'text':
-            return Response(result or "", status=200, mimetype='text/plain; charset=utf-8')
-        return jsonify({'message': result})
-        
+        logger.info(
+            "/call_openai succeeded in %.3fs (response_len=%d)",
+            duration,
+            len(result or ""),
+        )
+        if request.args.get("format") == "text":
+            return Response(
+                result or "", status=200, mimetype="text/plain; charset=utf-8"
+            )
+        return jsonify({"message": result})
+
     except Exception as e:
-        REQUEST_COUNT.labels(method='POST', endpoint='/call_openai', status='500').inc()
+        REQUEST_COUNT.labels(method="POST", endpoint="/call_openai", status="500").inc()
         logger.exception("/call_openai failed: %s", e)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
     finally:
-        REQUEST_LATENCY.labels(method='POST', endpoint='/call_openai').observe(time.time() - start_time)
+        REQUEST_LATENCY.labels(method="POST", endpoint="/call_openai").observe(
+            time.time() - start_time
+        )
 
 
-@bp.route('/call_gemini', methods=['POST'])
+@bp.route("/call_gemini", methods=["POST"])
 def call_gemini():
     """Call Google Gemini model"""
     start_time = time.time()
@@ -70,9 +82,9 @@ def call_gemini():
         if data is None:
             logger.warning("/call_gemini received no JSON body")
         else:
-            req_keys = [k for k in data.keys() if k != 'api_key']
-            user_text_len = len(data.get('user_text') or '')
-            prompting_strategy = data.get('prompting_strategie', 'few_shot')
+            req_keys = [k for k in data.keys() if k != "api_key"]
+            user_text_len = len(data.get("user_text") or "")
+            prompting_strategy = data.get("prompting_strategie", "few_shot")
             logger.debug(
                 "call_gemini payload: keys=%s, user_text_len=%d, prompting_strategy=%s",
                 req_keys,
@@ -81,42 +93,50 @@ def call_gemini():
             )
         config_class = get_config()
         config_instance = config_class()
-        
+
         llm_service = LLMService()
         logger.info("Invoking LLMService.call_gemini")
         result = llm_service.call_gemini(
-            api_key=data.get('api_key'),
-            system_prompt=data.get('system_prompt', config_instance.SYSTEM_PROMPT),
-            user_text=data.get('user_text'),
-            prompting_strategy=data.get('prompting_strategie', 'few_shot')
+            api_key=data.get("api_key"),
+            system_prompt=data.get("system_prompt", config_instance.SYSTEM_PROMPT),
+            user_text=data.get("user_text"),
+            prompting_strategy=data.get("prompting_strategie", "few_shot"),
         )
-        
-        REQUEST_COUNT.labels(method='POST', endpoint='/call_gemini', status='200').inc()
+
+        REQUEST_COUNT.labels(method="POST", endpoint="/call_gemini", status="200").inc()
         duration = time.time() - start_time
-        logger.info("/call_gemini succeeded in %.3fs (response_len=%d)", duration, len(result or ''))
-        if request.args.get('format') == 'text':
-            return Response(result or "", status=200, mimetype='text/plain; charset=utf-8')
-        return jsonify({'message': result})
-        
+        logger.info(
+            "/call_gemini succeeded in %.3fs (response_len=%d)",
+            duration,
+            len(result or ""),
+        )
+        if request.args.get("format") == "text":
+            return Response(
+                result or "", status=200, mimetype="text/plain; charset=utf-8"
+            )
+        return jsonify({"message": result})
+
     except Exception as e:
-        REQUEST_COUNT.labels(method='POST', endpoint='/call_gemini', status='500').inc()
+        REQUEST_COUNT.labels(method="POST", endpoint="/call_gemini", status="500").inc()
         logger.exception("/call_gemini failed: %s", e)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({"error": str(e)}), 500
     finally:
-        REQUEST_LATENCY.labels(method='POST', endpoint='/call_gemini').observe(time.time() - start_time)
+        REQUEST_LATENCY.labels(method="POST", endpoint="/call_gemini").observe(
+            time.time() - start_time
+        )
 
 
-@bp.route('/_/_/echo')
+@bp.route("/_/_/echo")
 def echo():
     """Health check endpoint"""
     logger.debug("Health check hit: /_/_/echo")
-    REQUEST_COUNT.labels(method='GET', endpoint='/_/_/echo', status='200').inc()
+    REQUEST_COUNT.labels(method="GET", endpoint="/_/_/echo", status="200").inc()
     return jsonify(success=True)
 
 
-@bp.route('/metrics')
+@bp.route("/metrics")
 def metrics():
     """Expose Prometheus metrics."""
     logger.debug("Metrics scraped: /metrics")
-    REQUEST_COUNT.labels(method='GET', endpoint='/metrics', status='200').inc()
-    return generate_latest(), 200, {'Content-Type': CONTENT_TYPE_LATEST}
+    REQUEST_COUNT.labels(method="GET", endpoint="/metrics", status="200").inc()
+    return generate_latest(), 200, {"Content-Type": CONTENT_TYPE_LATEST}

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -3,7 +3,7 @@ from app.api import bp
 from app.services.llm_service import LLMService
 from app.services import model_registry
 from config import get_config
-from flask import request, jsonify, Response
+from flask import request, jsonify
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # Logging konfigurieren
@@ -17,114 +17,6 @@ REQUEST_COUNT = Counter(
 REQUEST_LATENCY = Histogram(
     "http_request_duration_seconds", "HTTP request latency", ["method", "endpoint"]
 )
-CALL_OPENAI_DURATION = Histogram("call_openai_duration_seconds", "OpenAI call duration")
-
-
-@bp.route("/call_openai", methods=["POST"])
-def call_openai():
-    """Call OpenAI GPT model"""
-    start_time = time.time()
-    logger.info("Received request to /call_openai")
-    try:
-        data = request.get_json()
-        if data is None:
-            logger.warning("/call_openai received no JSON body")
-        else:
-            req_keys = [k for k in data.keys() if k != "api_key"]
-            user_text_len = len(data.get("user_text") or "")
-            prompting_strategy = data.get("prompting_strategie", "few_shot")
-            logger.debug(
-                "call_openai payload: keys=%s, user_text_len=%d, prompting_strategy=%s",
-                req_keys,
-                user_text_len,
-                prompting_strategy,
-            )
-        config_class = get_config()
-        config_instance = config_class()
-
-        llm_service = LLMService()
-        logger.info("Invoking LLMService.call_openai")
-        result = llm_service.call_openai(
-            api_key=data.get("api_key"),
-            system_prompt=data.get("system_prompt", config_instance.SYSTEM_PROMPT),
-            user_text=data.get("user_text"),
-            prompting_strategy=data.get("prompting_strategie", "few_shot"),
-        )
-
-        REQUEST_COUNT.labels(method="POST", endpoint="/call_openai", status="200").inc()
-        duration = time.time() - start_time
-        logger.info(
-            "/call_openai succeeded in %.3fs (response_len=%d)",
-            duration,
-            len(result or ""),
-        )
-        if request.args.get("format") == "text":
-            return Response(
-                result or "", status=200, mimetype="text/plain; charset=utf-8"
-            )
-        return jsonify({"message": result})
-
-    except Exception as e:
-        REQUEST_COUNT.labels(method="POST", endpoint="/call_openai", status="500").inc()
-        logger.exception("/call_openai failed: %s", e)
-        return jsonify({"error": str(e)}), 500
-    finally:
-        REQUEST_LATENCY.labels(method="POST", endpoint="/call_openai").observe(
-            time.time() - start_time
-        )
-
-
-@bp.route("/call_gemini", methods=["POST"])
-def call_gemini():
-    """Call Google Gemini model"""
-    start_time = time.time()
-    try:
-        data = request.get_json()
-        if data is None:
-            logger.warning("/call_gemini received no JSON body")
-        else:
-            req_keys = [k for k in data.keys() if k != "api_key"]
-            user_text_len = len(data.get("user_text") or "")
-            prompting_strategy = data.get("prompting_strategie", "few_shot")
-            logger.debug(
-                "call_gemini payload: keys=%s, user_text_len=%d, prompting_strategy=%s",
-                req_keys,
-                user_text_len,
-                prompting_strategy,
-            )
-        config_class = get_config()
-        config_instance = config_class()
-
-        llm_service = LLMService()
-        logger.info("Invoking LLMService.call_gemini")
-        result = llm_service.call_gemini(
-            api_key=data.get("api_key"),
-            system_prompt=data.get("system_prompt", config_instance.SYSTEM_PROMPT),
-            user_text=data.get("user_text"),
-            prompting_strategy=data.get("prompting_strategie", "few_shot"),
-        )
-
-        REQUEST_COUNT.labels(method="POST", endpoint="/call_gemini", status="200").inc()
-        duration = time.time() - start_time
-        logger.info(
-            "/call_gemini succeeded in %.3fs (response_len=%d)",
-            duration,
-            len(result or ""),
-        )
-        if request.args.get("format") == "text":
-            return Response(
-                result or "", status=200, mimetype="text/plain; charset=utf-8"
-            )
-        return jsonify({"message": result})
-
-    except Exception as e:
-        REQUEST_COUNT.labels(method="POST", endpoint="/call_gemini", status="500").inc()
-        logger.exception("/call_gemini failed: %s", e)
-        return jsonify({"error": str(e)}), 500
-    finally:
-        REQUEST_LATENCY.labels(method="POST", endpoint="/call_gemini").observe(
-            time.time() - start_time
-        )
 
 
 # --- v2 contract API (consumed by t2p-2.0) --------------------------------

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,9 +1,12 @@
-import logging, time
+import logging
+import time
+
+from flask import Response, jsonify, request
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
+
 from app.api import bp
 from app.services.llm_service import LLMService
 from config import get_config
-from flask import request, jsonify, Response
-from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # Logging konfigurieren
 logging.basicConfig(level=logging.INFO)
@@ -17,6 +20,94 @@ REQUEST_LATENCY = Histogram(
     "http_request_duration_seconds", "HTTP request latency", ["method", "endpoint"]
 )
 CALL_OPENAI_DURATION = Histogram("call_openai_duration_seconds", "OpenAI call duration")
+SUPPORTED_MODELS = [
+    {"provider": "openai", "model": "gpt-4o", "default": True},
+    {"provider": "gemini", "model": "gemini-1.5-pro", "default": False},
+]
+
+
+def _error_response(status_code, code, message):
+    return jsonify({"error": {"code": code, "message": message}}), status_code
+
+
+def _extract_bearer_token():
+    auth = request.headers.get("Authorization", "")
+    parts = auth.split()
+    if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1]:
+        return parts[1]
+    return None
+
+
+@bp.route("/models", methods=["GET"])
+def models():
+    return jsonify({"models": SUPPORTED_MODELS}), 200
+
+
+@bp.route("/generate", methods=["POST"])
+def generate():
+    """Dispatch a contract-based generation request to a supported provider."""
+    start_time = time.time()
+    status = "200"
+    try:
+        api_key = _extract_bearer_token()
+        if api_key is None:
+            status = "400"
+            return _error_response(
+                400, "invalid_request", "Missing or malformed bearer token."
+            )
+
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            status = "400"
+            return _error_response(400, "invalid_request", "Request body must be JSON.")
+
+        missing = [
+            field for field in ("user_text", "provider", "model") if not data.get(field)
+        ]
+        if missing:
+            status = "400"
+            return _error_response(
+                400,
+                "invalid_request",
+                f"Missing or empty field(s): {', '.join(missing)}.",
+            )
+
+        supported = any(
+            item["provider"] == data["provider"] and item["model"] == data["model"]
+            for item in SUPPORTED_MODELS
+        )
+        if not supported:
+            status = "400"
+            return _error_response(
+                400,
+                "invalid_provider",
+                "Unsupported provider/model combination.",
+            )
+
+        config_instance = get_config()()
+        strategy = data.get("prompting_strategy", "few_shot")
+        service = LLMService()
+        if data["provider"] == "openai":
+            result = service.call_openai(
+                api_key, config_instance.SYSTEM_PROMPT, data["user_text"], strategy
+            )
+        else:
+            result = service.call_gemini(
+                api_key, config_instance.SYSTEM_PROMPT, data["user_text"], strategy
+            )
+        return jsonify({"raw_response": result}), 200
+    except ValueError as exc:
+        status = "400"
+        return _error_response(400, "invalid_request", str(exc))
+    except Exception:
+        status = "500"
+        logger.exception("/generate failed")
+        return _error_response(500, "upstream_error", "Provider request failed.")
+    finally:
+        REQUEST_COUNT.labels(method="POST", endpoint="/generate", status=status).inc()
+        REQUEST_LATENCY.labels(method="POST", endpoint="/generate").observe(
+            time.time() - start_time
+        )
 
 
 @bp.route("/call_openai", methods=["POST"])

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -166,9 +166,9 @@ def generate():
     try:
         api_key = _extract_bearer_key()
         if api_key is None:
-            status = "400"
+            status = "401"
             return _v2_error(
-                400, "invalid_request", "Missing or malformed Authorization header."
+                401, "unauthorized", "Missing or malformed Authorization header."
             )
 
         data = request.get_json(silent=True)
@@ -213,9 +213,7 @@ def generate():
     except Exception as e:
         status = "500"
         logger.exception("/generate failed: %s", e)
-        return _v2_error(
-            500, "upstream_error", "The LLM provider call failed."
-        )
+        return _v2_error(500, "upstream_error", "The LLM provider call failed.")
     finally:
         REQUEST_COUNT.labels(method="POST", endpoint="/generate", status=status).inc()
         REQUEST_LATENCY.labels(method="POST", endpoint="/generate").observe(

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -131,7 +131,7 @@ def call_gemini():
 #
 # t2p-2.0's ConnectorClient calls these two endpoints:
 #   POST <connector>/generate   body {user_text, provider, model}, Bearer auth
-#   GET  <connector>/models     -> {"models": [{provider, model, default}]}
+#   GET  <connector>/models     -> {"models": [{provider, model}]}
 # The error body shape is {"error": {"code": str, "message": str}} so t2p-2.0
 # can relay 4xx client errors unchanged.
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,12 +1,9 @@
-import logging
-import time
-
-from flask import Response, jsonify, request
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Histogram, generate_latest
-
+import logging, time
 from app.api import bp
 from app.services.llm_service import LLMService
 from config import get_config
+from flask import request, jsonify, Response
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
 # Logging konfigurieren
 logging.basicConfig(level=logging.INFO)
@@ -20,94 +17,6 @@ REQUEST_LATENCY = Histogram(
     "http_request_duration_seconds", "HTTP request latency", ["method", "endpoint"]
 )
 CALL_OPENAI_DURATION = Histogram("call_openai_duration_seconds", "OpenAI call duration")
-SUPPORTED_MODELS = [
-    {"provider": "openai", "model": "gpt-4o", "default": True},
-    {"provider": "gemini", "model": "gemini-1.5-pro", "default": False},
-]
-
-
-def _error_response(status_code, code, message):
-    return jsonify({"error": {"code": code, "message": message}}), status_code
-
-
-def _extract_bearer_token():
-    auth = request.headers.get("Authorization", "")
-    parts = auth.split()
-    if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1]:
-        return parts[1]
-    return None
-
-
-@bp.route("/models", methods=["GET"])
-def models():
-    return jsonify({"models": SUPPORTED_MODELS}), 200
-
-
-@bp.route("/generate", methods=["POST"])
-def generate():
-    """Dispatch a contract-based generation request to a supported provider."""
-    start_time = time.time()
-    status = "200"
-    try:
-        api_key = _extract_bearer_token()
-        if api_key is None:
-            status = "400"
-            return _error_response(
-                400, "invalid_request", "Missing or malformed bearer token."
-            )
-
-        data = request.get_json(silent=True)
-        if not isinstance(data, dict):
-            status = "400"
-            return _error_response(400, "invalid_request", "Request body must be JSON.")
-
-        missing = [
-            field for field in ("user_text", "provider", "model") if not data.get(field)
-        ]
-        if missing:
-            status = "400"
-            return _error_response(
-                400,
-                "invalid_request",
-                f"Missing or empty field(s): {', '.join(missing)}.",
-            )
-
-        supported = any(
-            item["provider"] == data["provider"] and item["model"] == data["model"]
-            for item in SUPPORTED_MODELS
-        )
-        if not supported:
-            status = "400"
-            return _error_response(
-                400,
-                "invalid_provider",
-                "Unsupported provider/model combination.",
-            )
-
-        config_instance = get_config()()
-        strategy = data.get("prompting_strategy", "few_shot")
-        service = LLMService()
-        if data["provider"] == "openai":
-            result = service.call_openai(
-                api_key, config_instance.SYSTEM_PROMPT, data["user_text"], strategy
-            )
-        else:
-            result = service.call_gemini(
-                api_key, config_instance.SYSTEM_PROMPT, data["user_text"], strategy
-            )
-        return jsonify({"raw_response": result}), 200
-    except ValueError as exc:
-        status = "400"
-        return _error_response(400, "invalid_request", str(exc))
-    except Exception:
-        status = "500"
-        logger.exception("/generate failed")
-        return _error_response(500, "upstream_error", "Provider request failed.")
-    finally:
-        REQUEST_COUNT.labels(method="POST", endpoint="/generate", status=status).inc()
-        REQUEST_LATENCY.labels(method="POST", endpoint="/generate").observe(
-            time.time() - start_time
-        )
 
 
 @bp.route("/call_openai", methods=["POST"])

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,3 @@
 from .llm_service import LLMService
 
-__all__ = ['LLMService']
+__all__ = ["LLMService"]

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 class LLMService:
     """Service class for handling LLM API calls"""
-    
+
     def __init__(self):
         self.prompt_builder = PromptBuilder()
-    
+
     def call_openai(self, api_key, system_prompt, user_text, prompting_strategy):
         """Call OpenAI GPT model"""
         if not user_text:
@@ -33,11 +33,11 @@ class LLMService:
             chat_completion = client.chat.completions.create(
                 messages=[
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt}
+                    {"role": "user", "content": prompt},
                 ],
                 temperature=0,
                 model="gpt-4o",
-                max_tokens=4096
+                max_tokens=4096,
             )
             content = chat_completion.choices[0].message.content or ""
             duration = time.time() - start_time
@@ -50,7 +50,7 @@ class LLMService:
         except Exception as e:
             logger.exception("OpenAI call failed: %s", e)
             raise
-    
+
     def call_gemini(self, api_key, system_prompt, user_text, prompting_strategy):
         """Call Google Gemini model"""
         if not user_text:
@@ -67,8 +67,7 @@ class LLMService:
         genai.configure(api_key=api_key)
 
         model = genai.GenerativeModel(
-            model_name="gemini-1.5-pro",
-            system_instruction=system_prompt
+            model_name="gemini-1.5-pro", system_instruction=system_prompt
         )
 
         try:
@@ -76,11 +75,8 @@ class LLMService:
             response = model.generate_content(
                 prompt,
                 generation_config=genai.types.GenerationConfig(
-                    temperature=0.0,
-                    top_k=1,
-                    top_p=1.0,
-                    max_output_tokens=2048
-                )
+                    temperature=0.0, top_k=1, top_p=1.0, max_output_tokens=2048
+                ),
             )
             text = (response.text or "") if hasattr(response, "text") else ""
             duration = time.time() - start_time

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -87,13 +87,13 @@ class LLMService:
 
         genai.configure(api_key=api_key)
 
-        model = genai.GenerativeModel(
+        gen_model = genai.GenerativeModel(
             model_name=model, system_instruction=system_prompt
         )
 
         try:
-            logger.info("Calling Gemini generate_content")
-            response = model.generate_content(
+            logger.info("Calling Gemini generate_content (model=%s)", model)
+            response = gen_model.generate_content(
                 prompt,
                 generation_config=genai.types.GenerationConfig(
                     temperature=0.0, top_k=1, top_p=1.0, max_output_tokens=2048

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -3,6 +3,7 @@ import time
 from openai import OpenAI
 import google.generativeai as genai
 from app.utils.prompt_builder import PromptBuilder
+from app.services import model_registry
 
 
 logger = logging.getLogger(__name__)
@@ -14,29 +15,37 @@ class LLMService:
     def __init__(self):
         self.prompt_builder = PromptBuilder()
 
-    def call_openai(self, api_key, system_prompt, user_text, prompting_strategy):
-        """Call OpenAI GPT model"""
+    def call_openai(
+        self, api_key, system_prompt, user_text, prompting_strategy, model="gpt-4o"
+    ):
+        """Call OpenAI GPT model.
+
+        ``model`` defaults to ``gpt-4o`` so existing (v1) callers and tests keep
+        working; the v2 ``/generate`` flow passes the model selected from the
+        registry.
+        """
         if not user_text:
             logger.warning("call_openai: empty user_text provided")
         start_time = time.time()
         prompt = self.prompt_builder.build_prompt(prompting_strategy, user_text)
         logger.debug(
-            "call_openai: strategy=%s, user_text_len=%d, prompt_len=%d",
+            "call_openai: strategy=%s, model=%s, user_text_len=%d, prompt_len=%d",
             prompting_strategy,
+            model,
             len(user_text or ""),
             len(prompt or ""),
         )
         client = OpenAI(api_key=api_key)
 
         try:
-            logger.info("Calling OpenAI chat.completions (model=gpt-4o)")
+            logger.info("Calling OpenAI chat.completions (model=%s)", model)
             chat_completion = client.chat.completions.create(
                 messages=[
                     {"role": "system", "content": system_prompt},
                     {"role": "user", "content": prompt},
                 ],
                 temperature=0,
-                model="gpt-4o",
+                model=model,
                 max_tokens=4096,
             )
             content = chat_completion.choices[0].message.content or ""
@@ -51,15 +60,27 @@ class LLMService:
             logger.exception("OpenAI call failed: %s", e)
             raise
 
-    def call_gemini(self, api_key, system_prompt, user_text, prompting_strategy):
-        """Call Google Gemini model"""
+    def call_gemini(
+        self,
+        api_key,
+        system_prompt,
+        user_text,
+        prompting_strategy,
+        model="gemini-1.5-pro",
+    ):
+        """Call Google Gemini model.
+
+        ``model`` defaults to ``gemini-1.5-pro`` for backward compatibility; the
+        v2 ``/generate`` flow passes the model selected from the registry.
+        """
         if not user_text:
             logger.warning("call_gemini: empty user_text provided")
         start_time = time.time()
         prompt = self.prompt_builder.build_prompt(prompting_strategy, user_text)
         logger.debug(
-            "call_gemini: strategy=%s, user_text_len=%d, prompt_len=%d",
+            "call_gemini: strategy=%s, model=%s, user_text_len=%d, prompt_len=%d",
             prompting_strategy,
+            model,
             len(user_text or ""),
             len(prompt or ""),
         )
@@ -67,11 +88,11 @@ class LLMService:
         genai.configure(api_key=api_key)
 
         model = genai.GenerativeModel(
-            model_name="gemini-1.5-pro", system_instruction=system_prompt
+            model_name=model, system_instruction=system_prompt
         )
 
         try:
-            logger.info("Calling Gemini generate_content (model=gemini-1.5-pro)")
+            logger.info("Calling Gemini generate_content")
             response = model.generate_content(
                 prompt,
                 generation_config=genai.types.GenerationConfig(
@@ -89,3 +110,24 @@ class LLMService:
         except Exception as e:
             logger.exception("Gemini call failed: %s", e)
             raise
+
+    def generate(self, api_key, provider, model, user_text, system_prompt,
+                 prompting_strategy="few_shot"):
+        """Provider-agnostic entry point used by the v2 ``/generate`` route.
+
+        Looks up the dispatch method for ``provider`` in the registry and calls
+        it with the registry-selected ``model``. Raises ``ValueError`` if the
+        provider has no dispatch mapping (the route validates the pair against
+        the registry first, so this is a defensive guard).
+        """
+        method_name = model_registry.dispatch_method(provider)
+        if method_name is None:
+            raise ValueError(f"Unsupported provider: {provider}")
+        method = getattr(self, method_name)
+        return method(
+            api_key=api_key,
+            system_prompt=system_prompt,
+            user_text=user_text,
+            prompting_strategy=prompting_strategy,
+            model=model,
+        )

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -1,0 +1,54 @@
+"""Central registry of supported provider/model pairs.
+
+This is the single source of truth used by both:
+
+* ``GET /models`` — to advertise the available provider/model pairs, and
+* ``POST /generate`` — to validate the requested ``provider``/``model`` and to
+  decide which ``LLMService`` method handles the call.
+
+Keeping the registry here (instead of inline in the routes) means the advertised
+list and the accepted list can never drift apart.
+"""
+
+# Each entry: provider key -> {model name -> is_default}.
+# Exactly one (provider, model) pair should be marked as the default; it mirrors
+# the legacy default used by t2p-2.0 (provider=openai, model=gpt-4o).
+_REGISTRY = {
+    "openai": {
+        "gpt-4o": True,
+    },
+    "gemini": {
+        "gemini-1.5-pro": False,
+    },
+}
+
+# Maps a provider to the LLMService method name that dispatches the call.
+_DISPATCH = {
+    "openai": "call_openai",
+    "gemini": "call_gemini",
+}
+
+
+def list_models():
+    """Return the advertised models as a flat list of dicts.
+
+    Shape (matches the connector contract / openapi.yaml):
+    ``[{"provider": str, "model": str, "default": bool}, ...]``
+    """
+    models = []
+    for provider, model_map in _REGISTRY.items():
+        for model, is_default in model_map.items():
+            models.append(
+                {"provider": provider, "model": model, "default": bool(is_default)}
+            )
+    return models
+
+
+def is_valid(provider, model):
+    """Return True if the given provider/model pair is supported."""
+    return model in _REGISTRY.get(provider, {})
+
+
+def dispatch_method(provider):
+    """Return the LLMService method name for a provider, or None if unknown."""
+    return _DISPATCH.get(provider)

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -10,16 +10,10 @@ Keeping the registry here (instead of inline in the routes) means the advertised
 list and the accepted list can never drift apart.
 """
 
-# Each entry: provider key -> {model name -> is_default}.
-# Exactly one (provider, model) pair should be marked as the default; it mirrors
-# the legacy default used by t2p-2.0 (provider=openai, model=gpt-4o).
+# Each entry: provider key -> list of supported model names.
 _REGISTRY = {
-    "openai": {
-        "gpt-4o": True,
-    },
-    "gemini": {
-        "gemini-1.5-pro": False,
-    },
+    "openai": ["gpt-4o"],
+    "gemini": ["gemini-1.5-pro"],
 }
 
 # Maps a provider to the LLMService method name that dispatches the call.
@@ -33,20 +27,18 @@ def list_models():
     """Return the advertised models as a flat list of dicts.
 
     Shape (matches the connector contract / openapi.yaml):
-    ``[{"provider": str, "model": str, "default": bool}, ...]``
+    ``[{"provider": str, "model": str}, ...]``
     """
-    models = []
-    for provider, model_map in _REGISTRY.items():
-        for model, is_default in model_map.items():
-            models.append(
-                {"provider": provider, "model": model, "default": bool(is_default)}
-            )
-    return models
+    return [
+        {"provider": provider, "model": model}
+        for provider, models in _REGISTRY.items()
+        for model in models
+    ]
 
 
 def is_valid(provider, model):
     """Return True if the given provider/model pair is supported."""
-    return model in _REGISTRY.get(provider, {})
+    return model in _REGISTRY.get(provider, ())
 
 
 def dispatch_method(provider):

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -2,4 +2,4 @@
 from .system_prompts import LLM_SYSTEM_PROMPT
 from .prompt_builder import PromptBuilder
 
-__all__ = ['LLM_SYSTEM_PROMPT', 'PromptBuilder']
+__all__ = ["LLM_SYSTEM_PROMPT", "PromptBuilder"]

--- a/app/utils/prompt_builder.py
+++ b/app/utils/prompt_builder.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 class PromptBuilder:
     """Class for building prompts with different strategies"""
-    
+
     def __init__(self):
         self.few_shot_templates = self._load_few_shot_templates()
-    
+
     def _load_few_shot_templates(self):
         """Load few-shot templates from JSON file"""
         template_path = Path(__file__).parent / "few_shot_templates.json"
@@ -17,20 +17,20 @@ class PromptBuilder:
         except Exception as e:
             print(f"Error loading few-shot templates: {e}")
             return []
-    
+
     def build_prompt(self, strategy, user_input):
         """Build prompt based on strategy"""
-        if strategy == 'few_shot':
+        if strategy == "few_shot":
             sections = [
                 f"Description:\n{example['description']}\n\nBPMN:\n{example['bpmn']}\n"
                 for example in self.few_shot_templates
-                if 'description' in example and 'bpmn' in example
+                if "description" in example and "bpmn" in example
             ]
             sections.append(f"Description:\n{user_input}\n\nBPMN:\n")
             return "\n".join(sections)
-        
-        elif strategy == 'zero_shot':
+
+        elif strategy == "zero_shot":
             return f"Please generate a BPMN model for the following description:\n\n{user_input}\n\nBPMN:"
-        
+
         else:
             raise ValueError(f"Unsupported prompting strategy: {strategy}")

--- a/app/utils/prompt_builder.py
+++ b/app/utils/prompt_builder.py
@@ -1,5 +1,8 @@
 import json
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 class PromptBuilder:
@@ -15,7 +18,7 @@ class PromptBuilder:
             with open(template_path, encoding="utf-8") as f:
                 return json.load(f)
         except Exception as e:
-            print(f"Error loading few-shot templates: {e}")
+            logger.warning("Error loading few-shot templates: %s", e)
             return []
 
     def build_prompt(self, strategy, user_input):

--- a/config.py
+++ b/config.py
@@ -1,26 +1,34 @@
 import os
 from app.utils import LLM_SYSTEM_PROMPT
 
+
 # === Base Configuration ===
 class BaseConfig:
     SYSTEM_PROMPT = LLM_SYSTEM_PROMPT
     TESTING = False
-    WTF_CSRF_ENABLED = os.environ.get('WTF_CSRF_ENABLED') or False
-    SECRET_KEY = os.environ.get('SECRET_KEY') or "fj92348759t182htpoihf9sd8gu98341hrpasdhuq8gpsiodfh9823r"
+    WTF_CSRF_ENABLED = os.environ.get("WTF_CSRF_ENABLED") or False
+    SECRET_KEY = (
+        os.environ.get("SECRET_KEY")
+        or "fj92348759t182htpoihf9sd8gu98341hrpasdhuq8gpsiodfh9823r"
+    )
+
 
 # === Development Configuration ===
 class DevelopmentConfig(BaseConfig):
     DEBUG = True
 
+
 # === Production Configuration ===
 class ProductionConfig(BaseConfig):
     DEBUG = False
+
 
 # === Testing Configuration ===
 class TestingConfig(BaseConfig):
     DEBUG = True
     TESTING = True
     WTF_CSRF_ENABLED = False
+
 
 # === Select Configuration Class Based on Environment ===
 def get_config():

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,26 +1,20 @@
-# LLM API connector — internal API contract (refactor)
+# LLM API Connector — Internal API
 
-Status: **proposed** — interface frozen for the `feature/api-refactor` work. Code does
-not implement this yet. This file is the source of truth both sides build against.
+Internal HTTP API consumed by t2p-2.0.
 
-This API is internal: t2p-2.0 is the only consumer. There are no other callers, so the
-old endpoints are deleted outright and both sides adapt — no versioning, no compat window.
+## Endpoints
 
-## Endpoint map
-
-| Method | Path | State |
-|--------|------|-------|
-| GET  | `/metrics`     | unchanged |
-| GET  | `/_/_/echo`    | unchanged |
-| POST | `/call_openai` | **removed** |
-| POST | `/call_gemini` | **removed** |
-| POST | `/generate`    | **new** |
-| GET  | `/models`      | **new** |
+| Method | Path |
+|--------|------|
+| POST | `/generate` |
+| GET  | `/models`   |
+| GET  | `/metrics`  |
+| GET  | `/_/_/echo` |
 
 ## `POST /generate`
 
 ```
-Header: Authorization: Bearer <api_key>   (the user's provider key, forwarded by t2p-2.0)
+Header: Authorization: Bearer <api_key>
 Body: {
   "user_text": string  (required)
   "provider":  string  (required)
@@ -31,11 +25,13 @@ Response 400: { "error": { "code": string, "message": string } }
 Response 500: { "error": { "code": string, "message": string } }
 ```
 
-The provider key travels in the `Authorization` header, never the body, so it is not
-logged alongside the payload (this removes the manual `api_key` stripping the old logging
-needed). Error codes: `invalid_request` / `invalid_provider` (400), `upstream_error` /
-`internal_error` (500). Auth presence/format is validated upstream by t2p-2.0
-(`401 unauthorized`); a missing/malformed header here is treated as `invalid_request`.
+The provider API key is supplied in the `Authorization` header. The connector builds the
+prompt, dispatches the call to the selected `provider`/`model`, and returns the raw
+provider response.
+
+Error codes: `invalid_request`, `invalid_provider` (400); `upstream_error`,
+`internal_error` (500). A missing or malformed `Authorization` header returns
+`400 invalid_request`.
 
 ## `GET /models`
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,6 +1,8 @@
 # LLM API Connector — Internal API
 
-Internal HTTP API consumed by t2p-2.0.
+Internal HTTP API consumed by t2p-2.0. The machine-readable form of this
+contract is [`docs/openapi.yaml`](openapi.yaml); this document is authoritative
+where the two disagree.
 
 ## Endpoints
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,0 +1,38 @@
+# LLM API connector — internal API contract (refactor)
+
+Status: **proposed** — interface frozen for the `feature/api-refactor` work. Code does
+not implement this yet. This file is the source of truth both sides build against.
+
+This API is internal: t2p-2.0 is the only consumer. There are no other callers, so the
+old endpoints are deleted outright and both sides adapt — no versioning, no compat window.
+
+## Endpoint map
+
+| Method | Path | State |
+|--------|------|-------|
+| GET  | `/metrics`     | unchanged |
+| GET  | `/_/_/echo`    | unchanged |
+| POST | `/call_openai` | **removed** |
+| POST | `/call_gemini` | **removed** |
+| POST | `/generate`    | **new** |
+| GET  | `/models`      | **new** |
+
+## `POST /generate`
+
+```
+Body: {
+  "api_key":   string  (required)
+  "user_text": string  (required)
+  "provider":  string  (required)
+  "model":     string  (required)
+}
+Response 200: { "raw_response": string }
+Response 400: { "error": { "code": string, "message": string } }
+Response 500: { "error": { "code": string, "message": string } }
+```
+
+## `GET /models`
+
+```
+Response 200: { "models": [{ "provider": string, "model": string, "default": bool }] }
+```

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -10,6 +10,8 @@ where the two disagree.
 |--------|------|
 | POST | `/generate` |
 | GET  | `/models`   |
+| POST | `/call_openai` |
+| POST | `/call_gemini` |
 | GET  | `/metrics`  |
 | GET  | `/_/_/echo` |
 
@@ -29,7 +31,9 @@ Response 500: { "error": { "code": string, "message": string } }
 
 The provider API key is supplied in the `Authorization` header. The connector builds the
 prompt, dispatches the call to the selected `provider`/`model`, and returns the raw
-provider response.
+provider response containing the BPMN structure JSON. The provider-specific
+`/call_openai` and `/call_gemini` operations remain available for existing
+internal callers.
 
 Error codes: `invalid_request`, `invalid_provider` (400); `upstream_error`,
 `internal_error` (500). A missing or malformed `Authorization` header returns

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -4,6 +4,13 @@ Internal HTTP API consumed by t2p-2.0. The machine-readable form of this
 contract is [`docs/openapi.yaml`](openapi.yaml); this document is authoritative
 where the two disagree.
 
+This connector is **internal — called solely by t2p-2.0** — and is the
+**authoritative validator** for the generate contract. It owns all request
+validation: the bearer token (and raw-key extraction from it), JSON-body shape,
+required-field presence, and provider/model validation against the registry.
+t2p-2.0 does not duplicate these guards; it forwards requests and relays the
+responses below (including 4xx) unchanged.
+
 ## Endpoints
 
 | Method | Path |
@@ -24,6 +31,7 @@ Body: {
 }
 Response 200: { "raw_response": string }
 Response 400: { "error": { "code": string, "message": string } }
+Response 401: { "error": { "code": string, "message": string } }
 Response 500: { "error": { "code": string, "message": string } }
 ```
 
@@ -31,9 +39,10 @@ The provider API key is supplied in the `Authorization` header. The connector bu
 prompt, dispatches the call to the selected `provider`/`model`, and returns the raw
 provider response.
 
-Error codes: `invalid_request`, `invalid_provider` (400); `upstream_error`,
-`internal_error` (500). A missing or malformed `Authorization` header returns
-`400 invalid_request`.
+Error codes: `invalid_request`, `invalid_provider` (400); `unauthorized` (401);
+`upstream_error`, `internal_error` (500). A missing or malformed `Authorization`
+header returns `401 unauthorized`; a non-JSON body or a missing/empty required
+field returns `400 invalid_request`.
 
 ## `GET /models`
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -10,8 +10,6 @@ where the two disagree.
 |--------|------|
 | POST | `/generate` |
 | GET  | `/models`   |
-| POST | `/call_openai` |
-| POST | `/call_gemini` |
 | GET  | `/metrics`  |
 | GET  | `/_/_/echo` |
 
@@ -31,9 +29,7 @@ Response 500: { "error": { "code": string, "message": string } }
 
 The provider API key is supplied in the `Authorization` header. The connector builds the
 prompt, dispatches the call to the selected `provider`/`model`, and returns the raw
-provider response containing the BPMN structure JSON. The provider-specific
-`/call_openai` and `/call_gemini` operations remain available for existing
-internal callers.
+provider response.
 
 Error codes: `invalid_request`, `invalid_provider` (400); `upstream_error`,
 `internal_error` (500). A missing or malformed `Authorization` header returns

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -38,5 +38,5 @@ Error codes: `invalid_request`, `invalid_provider` (400); `upstream_error`,
 ## `GET /models`
 
 ```
-Response 200: { "models": [{ "provider": string, "model": string, "default": bool }] }
+Response 200: { "models": [{ "provider": string, "model": string }] }
 ```

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -20,8 +20,8 @@ old endpoints are deleted outright and both sides adapt — no versioning, no co
 ## `POST /generate`
 
 ```
+Header: Authorization: Bearer <api_key>   (the user's provider key, forwarded by t2p-2.0)
 Body: {
-  "api_key":   string  (required)
   "user_text": string  (required)
   "provider":  string  (required)
   "model":     string  (required)
@@ -30,6 +30,12 @@ Response 200: { "raw_response": string }
 Response 400: { "error": { "code": string, "message": string } }
 Response 500: { "error": { "code": string, "message": string } }
 ```
+
+The provider key travels in the `Authorization` header, never the body, so it is not
+logged alongside the payload (this removes the manual `api_key` stripping the old logging
+needed). Error codes: `invalid_request` / `invalid_provider` (400), `upstream_error` /
+`internal_error` (500). Auth presence/format is validated upstream by t2p-2.0
+(`401 unauthorized`); a missing/malformed header here is treated as `invalid_request`.
 
 ## `GET /models`
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,155 @@
+openapi: 3.0.3
+info:
+  title: WOPED T2P LLM API Connector — Internal API
+  description: |
+    Internal HTTP API consumed by t2p-2.0. It accepts a process description
+    plus a provider/model selection, builds the prompt, dispatches the call to
+    the chosen LLM provider, and returns the raw provider response.
+
+    This spec is the machine-readable form of `docs/api-contract.md`; when the
+    two disagree, the markdown contract is authoritative. Note: this describes
+    the agreed `/generate` + `/models` contract for the API refactor, which the
+    service code does not fully implement yet.
+  version: 1.0.0
+  contact:
+    name: API Support
+servers:
+  - url: http://localhost:5000
+    description: Local development server
+
+paths:
+  /generate:
+    post:
+      summary: Generate a model from a process description
+      description: >-
+        Builds the prompt, dispatches the call to the selected provider/model,
+        and returns the raw provider response. The provider API key is supplied
+        in the Authorization header and never appears in the body.
+      operationId: generate
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateRequest'
+      responses:
+        '200':
+          description: Generation successful
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateResult'
+        '400':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /models:
+    get:
+      summary: List available providers and models
+      operationId: models
+      responses:
+        '200':
+          description: Available models
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelsResponse'
+        '500':
+          $ref: '#/components/responses/Error'
+
+  /metrics:
+    get:
+      summary: Prometheus metrics
+      operationId: metrics
+      responses:
+        '200':
+          description: Metrics in Prometheus text exposition format
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /_/_/echo:
+    get:
+      summary: Liveness echo
+      operationId: echo
+      responses:
+        '200':
+          description: Service is reachable
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      description: "Provider API key, forwarded as `Authorization: Bearer <api_key>`."
+
+  responses:
+    Error:
+      description: Error response
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    GenerateRequest:
+      type: object
+      required: [user_text, provider, model]
+      properties:
+        user_text:
+          type: string
+          description: Natural-language process description.
+          example: "Start with a user request. Check inventory. If available, process the order; otherwise notify the user."
+        provider:
+          type: string
+          description: LLM provider; one of the values from GET /models.
+          example: openai
+        model:
+          type: string
+          description: Model name; one of the values from GET /models.
+          example: gpt-4o
+
+    GenerateResult:
+      type: object
+      properties:
+        raw_response:
+          type: string
+          description: The raw provider response.
+
+    ModelsResponse:
+      type: object
+      properties:
+        models:
+          type: array
+          items:
+            type: object
+            properties:
+              provider:
+                type: string
+                example: openai
+              model:
+                type: string
+                example: gpt-4o
+              default:
+                type: boolean
+                example: true
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: >-
+                Stable identifier. Known values: `invalid_request`,
+                `invalid_provider` (400); `upstream_error`, `internal_error` (500).
+              example: invalid_request
+            message:
+              type: string
+              example: "Missing or empty field(s): provider."

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -110,6 +110,11 @@ components:
           type: string
           description: Model name; one of the values from GET /models.
           example: gpt-4o
+        prompting_strategy:
+          type: string
+          description: Prompting strategy to use. Defaults to "few_shot" if omitted.
+          enum: [few_shot, zero_shot]
+          default: few_shot
 
     GenerateResult:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -132,9 +132,6 @@ components:
               model:
                 type: string
                 example: gpt-4o
-              default:
-                type: boolean
-                example: true
 
     Error:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7,9 +7,7 @@ info:
     the chosen LLM provider, and returns the raw provider response.
 
     This spec is the machine-readable form of `docs/api-contract.md`; when the
-    two disagree, the markdown contract is authoritative. Note: this describes
-    the agreed `/generate` + `/models` contract for the API refactor, which the
-    service code does not fully implement yet.
+    two disagree, the markdown contract is authoritative.
   version: 1.0.0
   contact:
     name: API Support

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -7,7 +7,9 @@ info:
     the chosen LLM provider, and returns the raw provider response.
 
     This spec is the machine-readable form of `docs/api-contract.md`; when the
-    two disagree, the markdown contract is authoritative.
+    two disagree, the markdown contract is authoritative. Note: this describes
+    the agreed `/generate` + `/models` contract for the API refactor, which the
+    service code does not fully implement yet.
   version: 1.0.0
   contact:
     name: API Support

--- a/llm-api-connector.py
+++ b/llm-api-connector.py
@@ -42,11 +42,5 @@ def setup_logging():
 setup_logging()
 app = create_app()
 
-
-@app.cli.command("test")
-def test():
-    """Run the unit tests."""
-    import unittest
-
-    tests = unittest.TestLoader().discover("tests")
-    unittest.TextTestRunner(verbosity=2).run(tests)
+# The ``flask test`` CLI command is registered in app/__init__.py (it reports a
+# non-zero exit code when tests fail); no duplicate registration here.

--- a/llm-api-connector.py
+++ b/llm-api-connector.py
@@ -5,12 +5,14 @@ from pythonjsonlogger import jsonlogger
 
 class MetricsFilter(logging.Filter):
     """Filter to exclude metrics endpoints from logs"""
+
     def filter(self, record):
         if record.name == "werkzeug":
             return "/metrics" not in record.getMessage()
         try:
             from flask import request
-            return not request.path.startswith('/metrics')
+
+            return not request.path.startswith("/metrics")
         except RuntimeError:
             return True
 
@@ -19,21 +21,20 @@ def setup_logging():
     """Setup logging configuration"""
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    
-    werkzeug_logger = logging.getLogger('werkzeug')
+
+    werkzeug_logger = logging.getLogger("werkzeug")
     werkzeug_logger.setLevel(logging.INFO)
-    
+
     metrics_filter = MetricsFilter()
-    
+
     console_handler = logging.StreamHandler()
     console_handler.addFilter(metrics_filter)
-    
+
     console_formatter = jsonlogger.JsonFormatter(
-        '%(asctime)s %(levelname)s %(name)s %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
+        "%(asctime)s %(levelname)s %(name)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
     console_handler.setFormatter(console_formatter)
-    
+
     logger.addHandler(console_handler)
     werkzeug_logger.addHandler(console_handler)
 
@@ -41,9 +42,11 @@ def setup_logging():
 setup_logging()
 app = create_app()
 
+
 @app.cli.command("test")
 def test():
     """Run the unit tests."""
     import unittest
-    tests = unittest.TestLoader().discover('tests')
+
+    tests = unittest.TestLoader().discover("tests")
     unittest.TextTestRunner(verbosity=2).run(tests)

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,6 +1,7 @@
 coverage==7.5.1
 Flask==3.1.2
 flask_cors==4.0.0
+flask-swagger-ui==5.21.0
 flask-wtf==1.2.1
 openai==1.79.0
 google-generativeai==0.8.5

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,55 +87,6 @@ class Test_App(unittest.TestCase):
         self.assertIn("message", data)
         self.assertEqual(data["message"], "Test Gemini response")
 
-    @patch("app.api.routes.LLMService")
-    def test_generate_dispatches_contract_request(self, mock_service):
-        mock_service.return_value.call_openai.return_value = '{"events": []}'
-
-        response = self.client.post(
-            "/generate",
-            headers={"Authorization": "Bearer test_api_key"},
-            json={
-                "user_text": "A process",
-                "provider": "openai",
-                "model": "gpt-4o",
-            },
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.get_json(), {"raw_response": '{"events": []}'})
-        mock_service.return_value.call_openai.assert_called_once()
-        self.assertEqual(
-            mock_service.return_value.call_openai.call_args.args[0], "test_api_key"
-        )
-
-    def test_generate_rejects_missing_bearer_token(self):
-        response = self.client.post(
-            "/generate",
-            json={"user_text": "A process", "provider": "openai", "model": "gpt-4o"},
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json()["error"]["code"], "invalid_request")
-
-    def test_generate_rejects_unsupported_model(self):
-        response = self.client.post(
-            "/generate",
-            headers={"Authorization": "Bearer test_api_key"},
-            json={"user_text": "A process", "provider": "openai", "model": "gpt-3"},
-        )
-
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json()["error"]["code"], "invalid_provider")
-
-    def test_models_lists_supported_contract_values(self):
-        response = self.client.get("/models")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(
-            {"provider": "openai", "model": "gpt-4o", "default": True},
-            response.get_json()["models"],
-        )
-
     def test_echo_endpoint(self):
         response = self.client.get("/_/_/echo")
         data = response.get_json()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,11 +11,11 @@ class Test_App(unittest.TestCase):
         self.client = self.app.test_client()
         self.app_context = self.app.app_context()
         self.app_context.push()
-        
+
         self.default_payload = {
-            'api_key': 'test_api_key',
-            'system_prompt': 'Du bist ein BPMN Generator.',
-            'user_text': 'Ein Kunde bestellt ein Produkt.'
+            "api_key": "test_api_key",
+            "system_prompt": "Du bist ein BPMN Generator.",
+            "user_text": "Ein Kunde bestellt ein Produkt.",
         }
 
     def tearDown(self):
@@ -33,69 +33,69 @@ class Test_App(unittest.TestCase):
     def mock_gemini_response(self, mock_genai):
         mock_response = MagicMock()
         mock_response.text = "Test Gemini response"
-        
+
         mock_model = MagicMock()
         mock_model.generate_content.return_value = mock_response
-        
+
         mock_genai.GenerativeModel.return_value = mock_model
 
-    @patch('app.services.llm_service.OpenAI')
+    @patch("app.services.llm_service.OpenAI")
     def test_call_openai_few_shot(self, mock_openai):
         self.mock_openai_response(mock_openai)
 
-        payload = {**self.default_payload, 'prompting_strategy': 'few_shot'}
-        response = self.client.post('/call_openai', json=payload)
+        payload = {**self.default_payload, "prompting_strategy": "few_shot"}
+        response = self.client.post("/call_openai", json=payload)
         data = response.get_json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('message', data)
-        self.assertEqual(data['message'], "Test response")
+        self.assertIn("message", data)
+        self.assertEqual(data["message"], "Test response")
 
-    @patch('app.services.llm_service.OpenAI')
+    @patch("app.services.llm_service.OpenAI")
     def test_call_openai_zero_shot(self, mock_openai):
         self.mock_openai_response(mock_openai)
 
-        payload = {**self.default_payload, 'prompting_strategy': 'zero_shot'}
-        response = self.client.post('/call_openai', json=payload)
+        payload = {**self.default_payload, "prompting_strategy": "zero_shot"}
+        response = self.client.post("/call_openai", json=payload)
         data = response.get_json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('message', data)
-        self.assertEqual(data['message'], "Test response")
+        self.assertIn("message", data)
+        self.assertEqual(data["message"], "Test response")
 
-    @patch('app.services.llm_service.genai')
+    @patch("app.services.llm_service.genai")
     def test_call_gemini_few_shot(self, mock_genai):
         self.mock_gemini_response(mock_genai)
 
-        payload = {**self.default_payload, 'prompting_strategy': 'few_shot'}
-        response = self.client.post('/call_gemini', json=payload)
+        payload = {**self.default_payload, "prompting_strategy": "few_shot"}
+        response = self.client.post("/call_gemini", json=payload)
         data = response.get_json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('message', data)
-        self.assertEqual(data['message'], "Test Gemini response")
+        self.assertIn("message", data)
+        self.assertEqual(data["message"], "Test Gemini response")
 
-    @patch('app.services.llm_service.genai')
+    @patch("app.services.llm_service.genai")
     def test_call_gemini_zero_shot(self, mock_genai):
         self.mock_gemini_response(mock_genai)
 
-        payload = {**self.default_payload, 'prompting_strategy': 'zero_shot'}
-        response = self.client.post('/call_gemini', json=payload)
+        payload = {**self.default_payload, "prompting_strategy": "zero_shot"}
+        response = self.client.post("/call_gemini", json=payload)
         data = response.get_json()
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn('message', data)
-        self.assertEqual(data['message'], "Test Gemini response")
+        self.assertIn("message", data)
+        self.assertEqual(data["message"], "Test Gemini response")
 
     def test_echo_endpoint(self):
-        response = self.client.get('/_/_/echo')
+        response = self.client.get("/_/_/echo")
         data = response.get_json()
-        
+
         self.assertEqual(response.status_code, 200)
-        self.assertIn('success', data)
-        self.assertTrue(data['success'])
+        self.assertIn("success", data)
+        self.assertTrue(data["success"])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch, MagicMock
 from app import create_app
 from config import TestingConfig
 import logging
@@ -12,80 +11,8 @@ class Test_App(unittest.TestCase):
         self.app_context = self.app.app_context()
         self.app_context.push()
 
-        self.default_payload = {
-            "api_key": "test_api_key",
-            "system_prompt": "Du bist ein BPMN Generator.",
-            "user_text": "Ein Kunde bestellt ein Produkt.",
-        }
-
     def tearDown(self):
         self.app_context.pop()
-
-    def mock_openai_response(self, mock_openai):
-        mock_choice = MagicMock()
-        mock_choice.message.content = "Test response"
-
-        mock_completion = MagicMock()
-        mock_completion.choices = [mock_choice]
-
-        mock_openai.return_value.chat.completions.create.return_value = mock_completion
-
-    def mock_gemini_response(self, mock_genai):
-        mock_response = MagicMock()
-        mock_response.text = "Test Gemini response"
-
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value = mock_response
-
-        mock_genai.GenerativeModel.return_value = mock_model
-
-    @patch("app.services.llm_service.OpenAI")
-    def test_call_openai_few_shot(self, mock_openai):
-        self.mock_openai_response(mock_openai)
-
-        payload = {**self.default_payload, "prompting_strategy": "few_shot"}
-        response = self.client.post("/call_openai", json=payload)
-        data = response.get_json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("message", data)
-        self.assertEqual(data["message"], "Test response")
-
-    @patch("app.services.llm_service.OpenAI")
-    def test_call_openai_zero_shot(self, mock_openai):
-        self.mock_openai_response(mock_openai)
-
-        payload = {**self.default_payload, "prompting_strategy": "zero_shot"}
-        response = self.client.post("/call_openai", json=payload)
-        data = response.get_json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("message", data)
-        self.assertEqual(data["message"], "Test response")
-
-    @patch("app.services.llm_service.genai")
-    def test_call_gemini_few_shot(self, mock_genai):
-        self.mock_gemini_response(mock_genai)
-
-        payload = {**self.default_payload, "prompting_strategy": "few_shot"}
-        response = self.client.post("/call_gemini", json=payload)
-        data = response.get_json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("message", data)
-        self.assertEqual(data["message"], "Test Gemini response")
-
-    @patch("app.services.llm_service.genai")
-    def test_call_gemini_zero_shot(self, mock_genai):
-        self.mock_gemini_response(mock_genai)
-
-        payload = {**self.default_payload, "prompting_strategy": "zero_shot"}
-        response = self.client.post("/call_gemini", json=payload)
-        data = response.get_json()
-
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("message", data)
-        self.assertEqual(data["message"], "Test Gemini response")
 
     def test_echo_endpoint(self):
         response = self.client.get("/_/_/echo")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,6 +87,55 @@ class Test_App(unittest.TestCase):
         self.assertIn("message", data)
         self.assertEqual(data["message"], "Test Gemini response")
 
+    @patch("app.api.routes.LLMService")
+    def test_generate_dispatches_contract_request(self, mock_service):
+        mock_service.return_value.call_openai.return_value = '{"events": []}'
+
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer test_api_key"},
+            json={
+                "user_text": "A process",
+                "provider": "openai",
+                "model": "gpt-4o",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"raw_response": '{"events": []}'})
+        mock_service.return_value.call_openai.assert_called_once()
+        self.assertEqual(
+            mock_service.return_value.call_openai.call_args.args[0], "test_api_key"
+        )
+
+    def test_generate_rejects_missing_bearer_token(self):
+        response = self.client.post(
+            "/generate",
+            json={"user_text": "A process", "provider": "openai", "model": "gpt-4o"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"]["code"], "invalid_request")
+
+    def test_generate_rejects_unsupported_model(self):
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer test_api_key"},
+            json={"user_text": "A process", "provider": "openai", "model": "gpt-3"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"]["code"], "invalid_provider")
+
+    def test_models_lists_supported_contract_values(self):
+        response = self.client.get("/models")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            {"provider": "openai", "model": "gpt-4o", "default": True},
+            response.get_json()["models"],
+        )
+
     def test_echo_endpoint(self):
         response = self.client.get("/_/_/echo")
         data = response.get_json()

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -7,7 +7,7 @@ from app.utils.prompt_builder import PromptBuilder
 class TestPromptBuilder(unittest.TestCase):
     def test_unsupported_strategy_raises(self):
         # The strategy is caller-supplied (forwarded from /generate's
-        # 'prompting_strategie' field), so an unknown value must be rejected
+        # 'prompting_strategy' field), so an unknown value must be rejected
         # rather than silently producing an empty/garbage prompt.
         with self.assertRaises(ValueError):
             PromptBuilder().build_prompt("bogus_strategy", "describe a process")

--- a/tests/test_prompt_builder.py
+++ b/tests/test_prompt_builder.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import patch
+
+from app.utils.prompt_builder import PromptBuilder
+
+
+class TestPromptBuilder(unittest.TestCase):
+    def test_unsupported_strategy_raises(self):
+        # The strategy is caller-supplied (forwarded from /generate's
+        # 'prompting_strategie' field), so an unknown value must be rejected
+        # rather than silently producing an empty/garbage prompt.
+        with self.assertRaises(ValueError):
+            PromptBuilder().build_prompt("bogus_strategy", "describe a process")
+
+    def test_zero_shot_embeds_user_input(self):
+        prompt = PromptBuilder().build_prompt("zero_shot", "ship the order")
+        self.assertIn("ship the order", prompt)
+
+    def test_few_shot_embeds_user_input(self):
+        prompt = PromptBuilder().build_prompt("few_shot", "ship the order")
+        self.assertIn("ship the order", prompt)
+
+    def test_template_load_failure_degrades_gracefully(self):
+        # If the few-shot template file is missing or unreadable, the builder
+        # must not crash on construction: it falls back to no examples and can
+        # still build a (user-input-only) few-shot prompt.
+        with patch("builtins.open", side_effect=OSError("missing file")):
+            builder = PromptBuilder()
+
+        self.assertEqual(builder.few_shot_templates, [])
+        prompt = builder.build_prompt("few_shot", "ship the order")
+        self.assertIn("ship the order", prompt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_t2p_service.py
+++ b/tests/test_t2p_service.py
@@ -3,59 +3,61 @@ from unittest.mock import patch, MagicMock
 import config
 from app.services.llm_service import LLMService
 
+
 class TestT2PService(unittest.TestCase):
     def setUp(self):
-        config_instance = config.get_config()()  
+        config_instance = config.get_config()()
         self.api_key = "test-api-key"  # Static test API key
         self.system_prompt = config_instance.SYSTEM_PROMPT
-        self.strategies = ['few_shot', 'zero_shot']
+        self.strategies = ["few_shot", "zero_shot"]
         self.llm_service = LLMService()
 
     def create_mock_response(self, sentence, expected_keywords, strategy):
         """Create a realistic mock response that contains the expected keywords."""
-        if strategy == 'few_shot':
+        if strategy == "few_shot":
             mock_response = f"""
-            Start Event: Customer initiates process with {sentence.split()[0] if sentence.split() else 'request'}
+            Start Event: Customer initiates process with {sentence.split()[0] if sentence.split() else "request"}
             
             Tasks/Activities:
             """
         else:
             mock_response = f"BPMN Model for: {sentence}\n\nElements:\n"
-        
+
         # Add expected keywords to the mock response
         for keyword in expected_keywords:
             mock_response += f"- Process step involving {keyword}\n"
-        
+
         mock_response += "\nEnd Event: Process completed successfully"
         return mock_response
 
-    @patch('app.services.llm_service.OpenAI')
+    @patch("app.services.llm_service.OpenAI")
     def run_test_case(self, sentence, expected_keywords, mock_openai):
         for strategy in self.strategies:
             with self.subTest(strategy=strategy):
                 # Setup mock
-                mock_response = self.create_mock_response(sentence, expected_keywords, strategy)
+                mock_response = self.create_mock_response(
+                    sentence, expected_keywords, strategy
+                )
                 mock_choice = MagicMock()
                 mock_choice.message.content = mock_response
 
                 mock_completion = MagicMock()
                 mock_completion.choices = [mock_choice]
 
-                mock_openai.return_value.chat.completions.create.return_value = mock_completion
+                mock_openai.return_value.chat.completions.create.return_value = (
+                    mock_completion
+                )
 
                 # Run test
                 result = self.llm_service.call_openai(
-                    self.api_key,
-                    self.system_prompt,
-                    sentence,
-                    strategy
+                    self.api_key, self.system_prompt, sentence, strategy
                 )
                 result_lower = result.lower()
 
                 for keyword in expected_keywords:
                     self.assertTrue(
                         keyword.lower() in result_lower,
-                        msg=f"Keyword '{keyword}' not found in response:\n{result}"
+                        msg=f"Keyword '{keyword}' not found in response:\n{result}",
                     )
 
                 print(f"[OpenAI | {strategy}] AI Response:\n{result}\n")
@@ -83,11 +85,9 @@ class TestT2PService(unittest.TestCase):
             "Once they are submitted, a loan manager approves the application. "
             "If the credit is insufficient, the application is rejected and the customer is informed."
         )
-        expected_keywords = [
-            "loan", "credit", "approve", "reject", "inform"
-        ]
+        expected_keywords = ["loan", "credit", "approve", "reject", "inform"]
         self.run_test_case(sentence, expected_keywords)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_t2p_service.py
+++ b/tests/test_t2p_service.py
@@ -88,6 +88,20 @@ class TestT2PService(unittest.TestCase):
         expected_keywords = ["loan", "credit", "approve", "reject", "inform"]
         self.run_test_case(sentence, expected_keywords)
 
+    def test_generate_unknown_provider_raises(self):
+        # generate() is the provider-agnostic entry point; a provider with no
+        # dispatch mapping must raise rather than fail obscurely later. This
+        # guard protects internal/direct callers that bypass the route's
+        # registry validation.
+        with self.assertRaises(ValueError):
+            self.llm_service.generate(
+                api_key=self.api_key,
+                provider="bogus",
+                model="whatever",
+                user_text="x",
+                system_prompt=self.system_prompt,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -1,0 +1,116 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from app import create_app
+from config import TestingConfig
+
+
+class TestV2Api(unittest.TestCase):
+    def setUp(self):
+        self.app = create_app(TestingConfig)
+        self.client = self.app.test_client()
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+
+    def tearDown(self):
+        self.app_context.pop()
+
+    # --- helpers ----------------------------------------------------------
+    def _mock_openai(self, mock_openai, content="RAW BPMN JSON"):
+        mock_choice = MagicMock()
+        mock_choice.message.content = content
+        mock_completion = MagicMock()
+        mock_completion.choices = [mock_choice]
+        mock_openai.return_value.chat.completions.create.return_value = mock_completion
+
+    def _mock_gemini(self, mock_genai, content="RAW GEMINI JSON"):
+        mock_response = MagicMock()
+        mock_response.text = content
+        mock_model = MagicMock()
+        mock_model.generate_content.return_value = mock_response
+        mock_genai.GenerativeModel.return_value = mock_model
+
+    # --- /models ----------------------------------------------------------
+    def test_models_returns_registry(self):
+        response = self.client.get("/models")
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn("models", data)
+        pairs = {(m["provider"], m["model"]): m["default"] for m in data["models"]}
+        self.assertIn(("openai", "gpt-4o"), pairs)
+        self.assertTrue(pairs[("openai", "gpt-4o")])  # default
+        self.assertIn(("gemini", "gemini-1.5-pro"), pairs)
+
+    # --- /generate success ------------------------------------------------
+    @patch("app.services.llm_service.OpenAI")
+    def test_generate_openai_success(self, mock_openai):
+        self._mock_openai(mock_openai)
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "describe a process", "provider": "openai", "model": "gpt-4o"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"raw_response": "RAW BPMN JSON"})
+        # The API key is taken from the header, never the body.
+        mock_openai.assert_called_once_with(api_key="secret-token")
+
+    @patch("app.services.llm_service.genai")
+    def test_generate_gemini_success(self, mock_genai):
+        self._mock_gemini(mock_genai)
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={
+                "user_text": "describe a process",
+                "provider": "gemini",
+                "model": "gemini-1.5-pro",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"raw_response": "RAW GEMINI JSON"})
+
+    # --- /generate validation --------------------------------------------
+    def test_generate_missing_bearer_is_400(self):
+        response = self.client.post(
+            "/generate",
+            json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"]["code"], "invalid_request")
+
+    def test_generate_missing_field_is_400(self):
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"provider": "openai", "model": "gpt-4o"},  # no user_text
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"]["code"], "invalid_request")
+
+    def test_generate_invalid_provider_is_400(self):
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "x", "provider": "bogus", "model": "gpt-4o"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"]["code"], "invalid_provider")
+
+    # --- /generate upstream failure --------------------------------------
+    @patch("app.services.llm_service.OpenAI")
+    def test_generate_provider_error_is_500_upstream(self, mock_openai):
+        mock_openai.return_value.chat.completions.create.side_effect = RuntimeError(
+            "boom"
+        )
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.get_json()["error"]["code"], "upstream_error")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -48,7 +48,11 @@ class TestV2Api(unittest.TestCase):
         response = self.client.post(
             "/generate",
             headers={"Authorization": "Bearer secret-token"},
-            json={"user_text": "describe a process", "provider": "openai", "model": "gpt-4o"},
+            json={
+                "user_text": "describe a process",
+                "provider": "openai",
+                "model": "gpt-4o",
+            },
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json(), {"raw_response": "RAW BPMN JSON"})
@@ -71,13 +75,13 @@ class TestV2Api(unittest.TestCase):
         self.assertEqual(response.get_json(), {"raw_response": "RAW GEMINI JSON"})
 
     # --- /generate validation --------------------------------------------
-    def test_generate_missing_bearer_is_400(self):
+    def test_generate_missing_bearer_is_401(self):
         response = self.client.post(
             "/generate",
             json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.get_json()["error"]["code"], "invalid_request")
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json()["error"]["code"], "unauthorized")
 
     def test_generate_missing_field_is_400(self):
         response = self.client.post(

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -114,6 +114,41 @@ class TestV2Api(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertEqual(response.get_json()["error"]["code"], "upstream_error")
 
+    @patch("app.services.llm_service.genai")
+    def test_generate_gemini_provider_error_is_500_upstream(self, mock_genai):
+        # The Gemini provider must map a provider-side failure to the same
+        # upstream_error 500 as OpenAI does (the OpenAI path is covered above;
+        # this closes the second-provider asymmetry).
+        mock_genai.GenerativeModel.return_value.generate_content.side_effect = (
+            RuntimeError("boom")
+        )
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={
+                "user_text": "x",
+                "provider": "gemini",
+                "model": "gemini-1.5-pro",
+            },
+        )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.get_json()["error"]["code"], "upstream_error")
+
+    # --- /generate malformed body ----------------------------------------
+    def test_generate_non_json_body_is_400(self):
+        # A valid bearer token but a body that is not JSON must be rejected as
+        # invalid_request, distinct from the missing-field case.
+        response = self.client.post(
+            "/generate",
+            headers={
+                "Authorization": "Bearer secret-token",
+                "Content-Type": "text/plain",
+            },
+            data="this is not json",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"]["code"], "invalid_request")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -36,9 +36,8 @@ class TestV2Api(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertIn("models", data)
-        pairs = {(m["provider"], m["model"]): m["default"] for m in data["models"]}
+        pairs = {(m["provider"], m["model"]) for m in data["models"]}
         self.assertIn(("openai", "gpt-4o"), pairs)
-        self.assertTrue(pairs[("openai", "gpt-4o")])  # default
         self.assertIn(("gemini", "gemini-1.5-pro"), pairs)
 
     # --- /generate success ------------------------------------------------

--- a/version.py
+++ b/version.py
@@ -2,7 +2,7 @@
 Version and metadata information for the LLM API Connector service.
 """
 
-__version__ = "1.3.2"
+__version__ = "1.4.0"
 __service_name__ = "LLM API Connector"
 __description__ = "Service for interfacing with LLM providers (OpenAI, Azure, etc.)"
 __author__ = "WoPeD Team"
@@ -12,8 +12,10 @@ __license__ = "See LICENSE file"
 __build_date__ = None
 __git_commit__ = None
 
-# API version
-__api_version__ = "v1"
+# Legacy: __api_version__ was intended as a URL prefix (e.g. /v1/...) but was
+# never imported or used anywhere in the codebase. Routes have no /v1 prefix
+# and get_version_info() is never called. Kept here for reference only.
+# __api_version__ = "v1"
 
 
 def get_version_info():
@@ -26,7 +28,7 @@ def get_version_info():
         "description": __description__,
         "author": __author__,
         "license": __license__,
-        "api_version": __api_version__,
+        # "api_version": __api_version__,  # legacy, see comment above
         "build_date": __build_date__,
         "git_commit": __git_commit__,
     }


### PR DESCRIPTION
## Summary

This branch reworks the LLM API connector into a clearly defined, internal **v2 contract**. The connector is now the **authoritative validator** for generation requests coming from t2p-2.0: it owns all request validation (bearer token, JSON shape, required fields, provider/model validation against a registry), so t2p-2.0 no longer duplicates these guards — it forwards requests and relays responses (including 4xx) unchanged.

## Key changes

**API contract (v2)**
- New endpoints `POST /generate` and `GET /models` (5112ecb, 564ccbd)
- Provider API key is passed exclusively as `Authorization: Bearer <key>` — never in the body (58ff20b)
- Structured errors with codes: `invalid_request`, `invalid_provider` (400), `unauthorized` (401), `upstream_error`, `internal_error` (500)
- Correct `401` on missing/malformed bearer token for `/generate` (c8eb504)
- Removed unused legacy endpoints `/call_openai` and `/call_gemini` (fabffcd) and the unused `default` flag from the `/models` contract (5a021b0)

**Service layer**
- New `model_registry` for provider/model validation
- Optimized `LLMService` instantiation and improved logging in the prompt builder (b82d5c7)
- Fixed the `prompting_strategy` field name (e56d22c)

**Documentation**
- New machine-readable `docs/openapi.yaml` (5671b34) plus Swagger UI at `/docs`
- New `docs/api-contract.md` as the authoritative contract description; connector marked as the authoritative validator (f842685, 9a654d8, b9c0bd6)
- README updated: call examples, bearer auth, test workflow, current project state (b4b5bda, e2355e8)

**Tests**
- New `tests/test_v2_api.py` (154 lines) and `tests/test_prompt_builder.py`
- Coverage for prompt strategies, provider dispatch, and request validation (87feacd)

**Misc**
- Bumped version to `1.4.0`, marked `api_version` as legacy (a087eee)
- Introduced `pre-commit` with ruff; applied `ruff-format` across the codebase (154ca01)

## Notes
- The intermediate "connector generation contract" approach (3c620c2) was intentionally reverted (29c184e) and replaced by the v2 implementation.

**Stats:** 21 commits · 22 files · +786 / −272
