### PR TITLE
feat: refresh model registry to GPT-5.x / Gemini-3.x standard tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,23 @@ Example request body for `POST /generate`:
 {
   "user_text": "A customer submits an order. A clerk checks the inventory ...",
   "provider": "openai",
-  "model": "gpt-4o",
+  "model": "gpt-5.4-mini",
   "prompting_strategy": "few_shot"
 }
 ```
 
-Use `GET /models` to retrieve the list of supported provider/model pairs. See `docs/openapi.yaml` or the Swagger UI at `/docs` for the full API contract.
+### Supported models
+
+| Provider | Model | Notes |
+|----------|-------|-------|
+| `openai` | `gpt-5.5` | Newest general-purpose standard model |
+| `openai` | `gpt-5.4-mini` | Cost-effective, recommended default |
+| `openai` | `gpt-5.4-nano` | Cheapest, high-volume / low-latency |
+| `openai` | `gpt-4o` | Legacy — kept for backward compatibility |
+| `gemini` | `gemini-3.5-flash` | Newest flash tier, best price/performance |
+| `gemini` | `gemini-3.1-flash-lite` | Cheapest, high-volume / low-latency |
+
+Use `GET /models` to retrieve the current list at runtime. See `docs/openapi.yaml` or the Swagger UI at `/docs` for the full API contract.
 
 ## Running the Application with Docker
 

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -23,6 +23,11 @@ class LLMService:
         ``model`` defaults to ``gpt-4o`` so existing (v1) callers and tests keep
         working; the v2 ``/generate`` flow passes the model selected from the
         registry.
+
+        The GPT-5.x generation rejects ``temperature`` and ``max_tokens`` and
+        expects ``max_completion_tokens`` instead, whereas ``gpt-4o`` still uses
+        the classic parameters. We branch on the model name so both work through
+        the same dispatch.
         """
         if not user_text:
             logger.warning("call_openai: empty user_text provided")
@@ -37,17 +42,24 @@ class LLMService:
         )
         client = OpenAI(api_key=api_key)
 
+        request_params = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+        }
+        # GPT-5.x (and the o-series) reject `temperature`/`max_tokens` and use
+        # `max_completion_tokens`; older models (gpt-4o) keep the classic params.
+        if model.startswith("gpt-5") or model.startswith("o"):
+            request_params["max_completion_tokens"] = 4096
+        else:
+            request_params["temperature"] = 0
+            request_params["max_tokens"] = 4096
+
         try:
             logger.info("Calling OpenAI chat.completions (model=%s)", model)
-            chat_completion = client.chat.completions.create(
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": prompt},
-                ],
-                temperature=0,
-                model=model,
-                max_tokens=4096,
-            )
+            chat_completion = client.chat.completions.create(**request_params)
             content = chat_completion.choices[0].message.content or ""
             duration = time.time() - start_time
             logger.info(
@@ -66,12 +78,13 @@ class LLMService:
         system_prompt,
         user_text,
         prompting_strategy,
-        model="gemini-1.5-pro",
+        model="gemini-3.5-flash",
     ):
         """Call Google Gemini model.
 
-        ``model`` defaults to ``gemini-1.5-pro`` for backward compatibility; the
-        v2 ``/generate`` flow passes the model selected from the registry.
+        ``model`` defaults to ``gemini-3.5-flash`` (the current standard flash
+        tier); the v2 ``/generate`` flow passes the model selected from the
+        registry.
         """
         if not user_text:
             logger.warning("call_gemini: empty user_text provided")

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -11,9 +11,27 @@ list and the accepted list can never drift apart.
 """
 
 # Each entry: provider key -> list of supported model names.
+#
+# We list the current GPT-5.x / Gemini-3.x generations, but deliberately stay on
+# the cost-effective *standard* tiers (mini / nano / flash) rather than the
+# flagship Pro tiers, which are far more expensive than this connector's
+# process-description workload needs. ``gpt-4o`` is the only legacy model kept,
+# purely for backward compatibility.
+#
+# NOTE: the GPT-5.x models reject ``temperature`` and ``max_tokens`` and require
+# ``max_completion_tokens`` instead; ``LLMService.call_openai`` handles that
+# parameter split, so every model below works with the live dispatch.
 _REGISTRY = {
-    "openai": ["gpt-4o"],
-    "gemini": ["gemini-1.5-pro"],
+    "openai": [
+        "gpt-5.5",  # newest general-purpose standard model
+        "gpt-5.4-mini",  # cost-effective, recommended default for this workload
+        "gpt-5.4-nano",  # cheapest, high-volume / low-latency
+        "gpt-4o",  # legacy, kept for backward compatibility
+    ],
+    "gemini": [
+        "gemini-3.5-flash",  # newest flash tier, best price/performance
+        "gemini-3.1-flash-lite",  # cheapest, high-volume / low-latency
+    ],
 }
 
 # Maps a provider to the LLMService method name that dispatches the call.

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -38,7 +38,7 @@ class TestV2Api(unittest.TestCase):
         self.assertIn("models", data)
         pairs = {(m["provider"], m["model"]) for m in data["models"]}
         self.assertIn(("openai", "gpt-4o"), pairs)
-        self.assertIn(("gemini", "gemini-1.5-pro"), pairs)
+        self.assertIn(("gemini", "gemini-3.5-flash"), pairs)
 
     # --- /generate success ------------------------------------------------
     @patch("app.services.llm_service.OpenAI")
@@ -67,7 +67,7 @@ class TestV2Api(unittest.TestCase):
             json={
                 "user_text": "describe a process",
                 "provider": "gemini",
-                "model": "gemini-1.5-pro",
+                "model": "gemini-3.5-flash",
             },
         )
         self.assertEqual(response.status_code, 200)
@@ -128,7 +128,7 @@ class TestV2Api(unittest.TestCase):
             json={
                 "user_text": "x",
                 "provider": "gemini",
-                "model": "gemini-1.5-pro",
+                "model": "gemini-3.5-flash",
             },
         )
         self.assertEqual(response.status_code, 500)


### PR DESCRIPTION
## Summary
Updates the model registry to the current model generations (GPT-5.x / Gemini-3.x), deliberately staying on the cost-effective *standard* tiers instead of the expensive flagship Pro tiers, since this connector's process-description workload does not need Pro models.

## Changes
- **`model_registry.py`**: Registry updated to GPT-5.x / Gemini-3.x
  - OpenAI: `gpt-5.5`, `gpt-5.4-mini` (recommended default), `gpt-5.4-nano`, `gpt-4o` (kept only as legacy for backward compatibility)
  - Gemini: `gemini-3.5-flash`, `gemini-3.1-flash-lite`
- **`llm_service.py`**:
  - `call_openai` now branches on the model — GPT-5.x / o-series reject `temperature`/`max_tokens` and require `max_completion_tokens`; `gpt-4o` keeps the classic parameters.
  - `call_gemini` default updated from `gemini-1.5-pro` to `gemini-3.5-flash`.
- **`README.md`**: Updated the example model and added a supported-models table.
- **`tests/test_v2_api.py`**: Adjusted tests to the new model names.

## Notes
- `gpt-4o` is intentionally retained as the only legacy model.
- The parameter split (`max_completion_tokens` vs. `max_tokens`/`temperature`) is centralized in `LLMService.call_openai`, so every listed model works through the same dispatch.
