### PR TITLE
feat: structured output, provider modernization & tooling hardening

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.9
     hooks:
+      - id: ruff
+        args: [--fix]
       - id: ruff-format
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -88,8 +88,13 @@ The application will be accessible at http://localhost:5000.
 Run the following commands from the **project root** (not the `tests` folder — the test suite needs to resolve the `app` package):
 
 ```bash
-coverage run -m unittest discover -s tests
+coverage run -m pytest
 ```
+> The suite runs under **pytest** (not `unittest discover`): several modules are
+> plain pytest functions — the validators and the few-shot guard — which
+> `unittest discover` silently skips. `flask test` uses pytest for the same
+> reason.
+
 You can then view the coverage report by running:
 ```bash
 coverage report

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,7 @@
-import sys, logging, time, os
+import logging
+import os
+import sys
+import time
 from config import get_config
 from flask import Flask, request, g, send_from_directory
 from flask_wtf.csrf import CSRFProtect
@@ -34,7 +37,7 @@ def create_app(config_class=None):
 
     # CSRF-Security
     if app.config.get("WTF_CSRF_ENABLED", True):
-        csrf = CSRFProtect(app)
+        CSRFProtect(app)  # registers itself on the app; no handle needed
         logger.info("CSRF protection enabled")
 
     # Register blueprints

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-import click, unittest, sys, logging, time, os
+import sys, logging, time, os
 from config import get_config
 from flask import Flask, request, g, send_from_directory
 from flask_wtf.csrf import CSRFProtect
@@ -84,20 +84,20 @@ def create_app(config_class=None):
     # CLI Commands
     @app.cli.command("test")
     def test():
-        """Run the unit tests."""
-        logger.info("Running unit tests...")
-        loader = unittest.TestLoader()
-        start_dir = "tests"
-        suite = loader.discover(start_dir)
+        """Run the full test suite with pytest.
 
-        runner = unittest.TextTestRunner(verbosity=2)
-        result = runner.run(suite)
+        Uses pytest rather than ``unittest`` discovery: several test modules are
+        written as plain pytest functions (the validators and the few-shot
+        guard), which ``unittest discover`` silently skips. Since CI runs this
+        command (``coverage run -m flask test``), discovery would leave the
+        whole validation layer untested there. pytest collects both styles.
+        """
+        import pytest
 
-        if result.wasSuccessful():
-            logger.info("All tests passed.")
-            return 0
-        else:
-            logger.error("Some tests failed.")
-            sys.exit(1)
+        logger.info("Running tests via pytest...")
+        exit_code = pytest.main(["tests", "-q"])
+        if exit_code != 0:
+            sys.exit(int(exit_code))
+        logger.info("All tests passed.")
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,8 +4,9 @@ from flask import Flask, request, g, send_from_directory
 from flask_wtf.csrf import CSRFProtect
 from flask_swagger_ui import get_swaggerui_blueprint
 
-# Logging konfigurieren
-logging.basicConfig(level=logging.INFO)
+# Logging is configured once, centrally, by setup_logging() in the entrypoint
+# (llm-api-connector.py). Modules only obtain a logger — calling basicConfig here
+# installed a second root handler and every line was emitted twice (plain + JSON).
 logger = logging.getLogger(__name__)
 
 

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -2,4 +2,6 @@ from flask import Blueprint
 
 bp = Blueprint("api", __name__)
 
-from app.api import routes
+# Imported for its side effect: registers the route handlers on `bp`. Must come
+# after `bp` is defined, hence the late import.
+from app.api import routes  # noqa: E402,F401

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -28,6 +28,13 @@ _llm_service = LLMService()
 # the first try, so this is one initial call plus two retries.
 _MAX_GENERATION_ATTEMPTS = 3
 
+# Temperature used when regenerating after a validation failure. The first
+# attempt runs deterministically (temperature 0); without a bump the identical
+# prompt would yield the identical invalid output, wasting the retries. Kept
+# small so the output still tracks the prompt closely. (Reasoning models that
+# reject temperature are unaffected — the provider call drops it for them.)
+_RETRY_TEMPERATURE = 0.3
+
 
 def _generate_validated(**generate_kwargs):
     """Generate a process model, regenerating until it passes validation.
@@ -42,6 +49,9 @@ def _generate_validated(**generate_kwargs):
     enforced structured output).
     """
     for attempt in range(1, _MAX_GENERATION_ATTEMPTS + 1):
+        # Deterministic first attempt; regenerations use a small non-zero
+        # temperature so a rejected output is not reproduced verbatim.
+        generate_kwargs["temperature"] = 0.0 if attempt == 1 else _RETRY_TEMPERATURE
         raw_response = _llm_service.generate(**generate_kwargs)
         try:
             model = json.loads(raw_response)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -6,8 +6,8 @@ from app.validation import validate_model, ValidationError
 from flask import request, jsonify, current_app
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
 
-# Logging konfigurieren
-logging.basicConfig(level=logging.INFO)
+# Logging is configured centrally in the entrypoint (see app/__init__.py);
+# modules only obtain a logger here.
 logger = logging.getLogger(__name__)
 
 # Prometheus Metriken

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,6 +1,6 @@
 import logging, time
 from app.api import bp
-from app.services.llm_service import LLMService
+from app.services.llm_service import LLMService, ProviderError
 from app.services import model_registry
 from flask import request, jsonify, current_app
 from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
@@ -105,10 +105,19 @@ def generate():
         )
         return jsonify({"raw_response": raw_response}), 200
 
+    except ProviderError as e:
+        # The upstream provider (OpenAI / Google) rejected or failed the call.
+        # Forward its real error text and mirror the upstream status so the
+        # calling service can debug and react (429 is retryable; otherwise it is
+        # a bad-gateway condition). The traceback is already logged in the
+        # service layer.
+        http_status = 429 if e.upstream_status == 429 else 502
+        status = str(http_status)
+        return _v2_error(http_status, "upstream_error", str(e))
     except Exception as e:
         status = "500"
         logger.exception("/generate failed: %s", e)
-        return _v2_error(500, "upstream_error", "The LLM provider call failed.")
+        return _v2_error(500, "internal_error", "An unexpected error occurred.")
     finally:
         REQUEST_COUNT.labels(method="POST", endpoint="/generate", status=status).inc()
         REQUEST_LATENCY.labels(method="POST", endpoint="/generate").observe(

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,4 +1,6 @@
-import json, logging, time
+import json
+import logging
+import time
 from app.api import bp
 from app.services.llm_service import LLMService, ProviderError
 from app.services import model_registry

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,55 @@
+"""Structured-output schema for the BPMN-JSON process model.
+
+A single Pydantic definition of the process model the LLM must return. It is the
+shared source of truth for *shape and type* correctness across both providers:
+
+* OpenAI's Responses API consumes it via ``text_format=ProcessModel``
+  (``responses.parse``), which compiles it into a strict JSON schema.
+* Google's ``google-genai`` SDK consumes the same class as ``response_schema``
+  together with ``response_mime_type="application/json"``.
+
+Using one Pydantic model for both keeps the enforced ``type`` literals, field
+names and nesting identical regardless of which provider answers.
+
+Scope: this schema guarantees valid JSON, the exact element/flow field names and
+the allowed ``type`` values (the case-sensitivity and "only return JSON" rules
+the prompt used to police by hand). It deliberately does NOT encode the semantic
+graph rules — exactly one start/end, connectivity, explicit splits/joins — which
+no JSON schema can express; those remain in ``app.validation``.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class Event(BaseModel):
+    id: str
+    type: Literal["startEvent", "endEvent"]
+    name: str
+
+
+class Task(BaseModel):
+    id: str
+    type: Literal["userTask", "serviceTask", "task"]
+    name: str
+
+
+class Gateway(BaseModel):
+    id: str
+    type: Literal["exclusiveGateway", "parallelGateway"]
+    name: str
+
+
+class Flow(BaseModel):
+    id: str
+    type: Literal["sequenceFlow"]
+    source: str
+    target: str
+
+
+class ProcessModel(BaseModel):
+    events: list[Event]
+    tasks: list[Task]
+    gateways: list[Gateway]
+    flows: list[Flow]

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -64,6 +64,30 @@ class LLMService:
         )
         return prompt, start_time
 
+    def _finish(self, provider, text, start_time):
+        """Normalise a successful response and log its timing.
+
+        Single source for the ``or ""`` + ``strip()`` and the duration log,
+        shared by both provider methods.
+        """
+        text = (text or "").strip()
+        logger.info(
+            "%s response received in %.3fs (len=%d)",
+            provider,
+            time.time() - start_time,
+            len(text),
+        )
+        return text
+
+    def _fail(self, provider, exc):
+        """Log the traceback and build a ProviderError for the failed call.
+
+        Call sites raise the returned error with ``from exc`` to keep the cause
+        chain intact.
+        """
+        logger.exception("%s call failed: %s", provider, exc)
+        return ProviderError(str(exc), _upstream_status(exc))
+
     def call_openai(
         self, api_key, system_prompt, user_text, prompting_strategy, model="gpt-4o"
     ):
@@ -81,7 +105,7 @@ class LLMService:
         registry.
         """
         prompt, start_time = self._prepare(
-            "call_openai", prompting_strategy, user_text, model
+            "openai", prompting_strategy, user_text, model
         )
         client = OpenAI(api_key=api_key)
 
@@ -97,17 +121,9 @@ class LLMService:
         try:
             logger.info("Calling OpenAI responses.create (model=%s)", model)
             response = client.responses.create(**request_params)
-            content = response.output_text or ""
-            duration = time.time() - start_time
-            logger.info(
-                "OpenAI response received in %.3fs (len=%d)",
-                duration,
-                len(content),
-            )
-            return content.strip()
+            return self._finish("openai", response.output_text, start_time)
         except Exception as e:
-            logger.exception("OpenAI call failed: %s", e)
-            raise ProviderError(str(e), _upstream_status(e)) from e
+            raise self._fail("openai", e) from e
 
     def call_gemini(
         self,
@@ -130,38 +146,35 @@ class LLMService:
         registry.
         """
         prompt, start_time = self._prepare(
-            "call_gemini", prompting_strategy, user_text, model
+            "gemini", prompting_strategy, user_text, model
         )
-
         client = genai.Client(api_key=api_key)
 
-        config_kwargs = {
+        # Gemini nests the generation settings in a `config` object (the only
+        # structural difference from OpenAI's flat params); everything else
+        # follows the same build-request_params-then-call(**request_params)
+        # pattern.
+        config = {
             "system_instruction": system_prompt,
             "max_output_tokens": _MAX_OUTPUT_TOKENS,
         }
         if model_registry.supports_temperature("gemini", model):
-            config_kwargs["temperature"] = 0.0
-            config_kwargs["top_k"] = 1
-            config_kwargs["top_p"] = 1.0
+            config["temperature"] = 0.0
+            config["top_k"] = 1
+            config["top_p"] = 1.0
+
+        request_params = {
+            "model": model,
+            "contents": prompt,
+            "config": genai.types.GenerateContentConfig(**config),
+        }
 
         try:
             logger.info("Calling Gemini generate_content (model=%s)", model)
-            response = client.models.generate_content(
-                model=model,
-                contents=prompt,
-                config=genai.types.GenerateContentConfig(**config_kwargs),
-            )
-            text = (response.text or "") if hasattr(response, "text") else ""
-            duration = time.time() - start_time
-            logger.info(
-                "Gemini response received in %.3fs (len=%d)",
-                duration,
-                len(text),
-            )
-            return text.strip()
+            response = client.models.generate_content(**request_params)
+            return self._finish("gemini", response.text, start_time)
         except Exception as e:
-            logger.exception("Gemini call failed: %s", e)
-            raise ProviderError(str(e), _upstream_status(e)) from e
+            raise self._fail("gemini", e) from e
 
     def generate(self, api_key, provider, model, user_text, system_prompt,
                  prompting_strategy="few_shot"):

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -3,6 +3,7 @@ import time
 from openai import OpenAI
 from google import genai
 from app.utils.prompt_builder import PromptBuilder
+from app.schemas import ProcessModel
 from app.services import model_registry
 
 
@@ -91,14 +92,23 @@ class LLMService:
     def call_openai(
         self, api_key, system_prompt, user_text, prompting_strategy, model="gpt-4o"
     ):
-        """Call an OpenAI model via the Responses API.
+        """Call an OpenAI model via the Responses API with Structured Outputs.
 
-        Uses ``client.responses.create`` — the interface OpenAI now recommends
-        for new projects — rather than the legacy Chat Completions endpoint. The
-        Responses API unifies the output-token parameter as ``max_output_tokens``
-        for every model, so the only model-dependent knob left is ``temperature``:
-        GPT-5.x / o-series reasoning models reject it, while ``gpt-4o`` accepts
-        it. That capability comes from the registry instead of a name heuristic.
+        Uses ``client.responses.parse`` — the interface OpenAI now recommends
+        for new projects — rather than the legacy Chat Completions endpoint, and
+        passes ``text_format=ProcessModel`` so the model is constrained to the
+        BPMN-JSON schema (a strict JSON schema is compiled from the Pydantic
+        model). This guarantees valid JSON and the exact element/flow ``type``
+        values, replacing the prompt's hand-written "only return JSON" rules.
+
+        The Responses API unifies the output-token parameter as
+        ``max_output_tokens`` for every model, so the only model-dependent knob
+        left is ``temperature``: GPT-5.x / o-series reasoning models reject it,
+        while ``gpt-4o`` accepts it. That capability comes from the registry
+        instead of a name heuristic.
+
+        Returns ``response.output_text`` — the raw JSON string — so the calling
+        service keeps receiving a string it can hand on unchanged.
 
         ``model`` defaults to ``gpt-4o`` so existing (v1) callers and tests keep
         working; the v2 ``/generate`` flow passes the model selected from the
@@ -114,13 +124,14 @@ class LLMService:
             "instructions": system_prompt,
             "input": prompt,
             "max_output_tokens": _MAX_OUTPUT_TOKENS,
+            "text_format": ProcessModel,
         }
         if model_registry.supports_temperature("openai", model):
             request_params["temperature"] = 0
 
         try:
-            logger.info("Calling OpenAI responses.create (model=%s)", model)
-            response = client.responses.create(**request_params)
+            logger.info("Calling OpenAI responses.parse (model=%s)", model)
+            response = client.responses.parse(**request_params)
             return self._finish("openai", response.output_text, start_time)
         except Exception as e:
             raise self._fail("openai", e) from e
@@ -141,6 +152,12 @@ class LLMService:
         requests carrying different API keys it was a race condition. A
         per-request client isolates each call's credentials.
 
+        Enforces structured output via ``response_mime_type="application/json"``
+        plus ``response_schema=ProcessModel`` — the same Pydantic schema the
+        OpenAI path uses — so Gemini is constrained to the BPMN-JSON shape and
+        ``type`` values instead of relying on the prompt's hand-written rules.
+        ``response.text`` is still the raw JSON string the caller hands on.
+
         ``model`` defaults to ``gemini-3.5-flash`` (the current standard flash
         tier); the v2 ``/generate`` flow passes the model selected from the
         registry.
@@ -157,6 +174,8 @@ class LLMService:
         config = {
             "system_instruction": system_prompt,
             "max_output_tokens": _MAX_OUTPUT_TOKENS,
+            "response_mime_type": "application/json",
+            "response_schema": ProcessModel,
         }
         if model_registry.supports_temperature("gemini", model):
             config["temperature"] = 0.0

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -1,12 +1,16 @@
 import logging
 import time
 from openai import OpenAI
-import google.generativeai as genai
+from google import genai
 from app.utils.prompt_builder import PromptBuilder
 from app.services import model_registry
 
 
 logger = logging.getLogger(__name__)
+
+# Upper bound on generated tokens, shared by both providers so the output budget
+# is consistent regardless of which model handles the request.
+_MAX_OUTPUT_TOKENS = 4096
 
 
 class LLMService:
@@ -15,52 +19,60 @@ class LLMService:
     def __init__(self):
         self.prompt_builder = PromptBuilder()
 
-    def call_openai(
-        self, api_key, system_prompt, user_text, prompting_strategy, model="gpt-4o"
-    ):
-        """Call OpenAI GPT model.
+    def _prepare(self, provider, prompting_strategy, user_text, model):
+        """Build the prompt and emit the shared pre-call logging.
 
-        ``model`` defaults to ``gpt-4o`` so existing (v1) callers and tests keep
-        working; the v2 ``/generate`` flow passes the model selected from the
-        registry.
-
-        The GPT-5.x generation rejects ``temperature`` and ``max_tokens`` and
-        expects ``max_completion_tokens`` instead, whereas ``gpt-4o`` still uses
-        the classic parameters. We branch on the model name so both work through
-        the same dispatch.
+        Returns ``(prompt, start_time)``. Factored out so both provider methods
+        share identical input handling, logging and timing.
         """
         if not user_text:
-            logger.warning("call_openai: empty user_text provided")
+            logger.warning("%s: empty user_text provided", provider)
         start_time = time.time()
         prompt = self.prompt_builder.build_prompt(prompting_strategy, user_text)
         logger.debug(
-            "call_openai: strategy=%s, model=%s, user_text_len=%d, prompt_len=%d",
+            "%s: strategy=%s, model=%s, user_text_len=%d, prompt_len=%d",
+            provider,
             prompting_strategy,
             model,
             len(user_text or ""),
             len(prompt or ""),
         )
+        return prompt, start_time
+
+    def call_openai(
+        self, api_key, system_prompt, user_text, prompting_strategy, model="gpt-4o"
+    ):
+        """Call an OpenAI model via the Responses API.
+
+        Uses ``client.responses.create`` — the interface OpenAI now recommends
+        for new projects — rather than the legacy Chat Completions endpoint. The
+        Responses API unifies the output-token parameter as ``max_output_tokens``
+        for every model, so the only model-dependent knob left is ``temperature``:
+        GPT-5.x / o-series reasoning models reject it, while ``gpt-4o`` accepts
+        it. That capability comes from the registry instead of a name heuristic.
+
+        ``model`` defaults to ``gpt-4o`` so existing (v1) callers and tests keep
+        working; the v2 ``/generate`` flow passes the model selected from the
+        registry.
+        """
+        prompt, start_time = self._prepare(
+            "call_openai", prompting_strategy, user_text, model
+        )
         client = OpenAI(api_key=api_key)
 
         request_params = {
             "model": model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": prompt},
-            ],
+            "instructions": system_prompt,
+            "input": prompt,
+            "max_output_tokens": _MAX_OUTPUT_TOKENS,
         }
-        # GPT-5.x (and the o-series) reject `temperature`/`max_tokens` and use
-        # `max_completion_tokens`; older models (gpt-4o) keep the classic params.
-        if model.startswith("gpt-5") or model.startswith("o"):
-            request_params["max_completion_tokens"] = 4096
-        else:
+        if model_registry.supports_temperature("openai", model):
             request_params["temperature"] = 0
-            request_params["max_tokens"] = 4096
 
         try:
-            logger.info("Calling OpenAI chat.completions (model=%s)", model)
-            chat_completion = client.chat.completions.create(**request_params)
-            content = chat_completion.choices[0].message.content or ""
+            logger.info("Calling OpenAI responses.create (model=%s)", model)
+            response = client.responses.create(**request_params)
+            content = response.output_text or ""
             duration = time.time() - start_time
             logger.info(
                 "OpenAI response received in %.3fs (len=%d)",
@@ -80,37 +92,39 @@ class LLMService:
         prompting_strategy,
         model="gemini-3.5-flash",
     ):
-        """Call Google Gemini model.
+        """Call a Google Gemini model via the unified ``google-genai`` SDK.
+
+        Uses a per-call ``genai.Client(api_key=...)`` instead of the deprecated
+        ``google-generativeai`` SDK's global ``genai.configure(...)``. The old
+        global configuration was process-wide mutable state: under concurrent
+        requests carrying different API keys it was a race condition. A
+        per-request client isolates each call's credentials.
 
         ``model`` defaults to ``gemini-3.5-flash`` (the current standard flash
         tier); the v2 ``/generate`` flow passes the model selected from the
         registry.
         """
-        if not user_text:
-            logger.warning("call_gemini: empty user_text provided")
-        start_time = time.time()
-        prompt = self.prompt_builder.build_prompt(prompting_strategy, user_text)
-        logger.debug(
-            "call_gemini: strategy=%s, model=%s, user_text_len=%d, prompt_len=%d",
-            prompting_strategy,
-            model,
-            len(user_text or ""),
-            len(prompt or ""),
+        prompt, start_time = self._prepare(
+            "call_gemini", prompting_strategy, user_text, model
         )
 
-        genai.configure(api_key=api_key)
+        client = genai.Client(api_key=api_key)
 
-        gen_model = genai.GenerativeModel(
-            model_name=model, system_instruction=system_prompt
-        )
+        config_kwargs = {
+            "system_instruction": system_prompt,
+            "max_output_tokens": _MAX_OUTPUT_TOKENS,
+        }
+        if model_registry.supports_temperature("gemini", model):
+            config_kwargs["temperature"] = 0.0
+            config_kwargs["top_k"] = 1
+            config_kwargs["top_p"] = 1.0
 
         try:
             logger.info("Calling Gemini generate_content (model=%s)", model)
-            response = gen_model.generate_content(
-                prompt,
-                generation_config=genai.types.GenerationConfig(
-                    temperature=0.0, top_k=1, top_p=1.0, max_output_tokens=2048
-                ),
+            response = client.models.generate_content(
+                model=model,
+                contents=prompt,
+                config=genai.types.GenerateContentConfig(**config_kwargs),
             )
             text = (response.text or "") if hasattr(response, "text") else ""
             duration = time.time() - start_time

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -242,8 +242,16 @@ class LLMService:
             )
         return self._finish("gemini", response.text, start_time)
 
-    def generate(self, api_key, provider, model, user_text, system_prompt,
-                 prompting_strategy="few_shot", temperature=0.0):
+    def generate(
+        self,
+        api_key,
+        provider,
+        model,
+        user_text,
+        system_prompt,
+        prompting_strategy="few_shot",
+        temperature=0.0,
+    ):
         """Provider-agnostic entry point used by the v2 ``/generate`` route.
 
         Looks up the dispatch method for ``provider`` in the registry and calls

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -99,7 +99,7 @@ class LLMService:
         system_prompt,
         user_text,
         prompting_strategy,
-        model="gpt-4o",
+        model="gpt-5.4-mini",
         temperature=0.0,
     ):
         """Call an OpenAI model via the Responses API with Structured Outputs.
@@ -124,9 +124,9 @@ class LLMService:
         Returns ``response.output_text`` — the raw JSON string — so the calling
         service keeps receiving a string it can hand on unchanged.
 
-        ``model`` defaults to ``gpt-4o`` so existing (v1) callers and tests keep
-        working; the v2 ``/generate`` flow passes the model selected from the
-        registry.
+        ``model`` defaults to ``gpt-5.4-mini`` — the registry's recommended
+        default — for direct (v1) callers and tests; the v2 ``/generate`` flow
+        passes the model selected from the registry.
         """
         prompt, start_time = self._prepare(
             "openai", prompting_strategy, user_text, model

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -13,6 +13,31 @@ logger = logging.getLogger(__name__)
 _MAX_OUTPUT_TOKENS = 4096
 
 
+class ProviderError(Exception):
+    """Raised when an upstream LLM provider (OpenAI / Google) call fails.
+
+    Carries the provider's own error text (via ``str``) and, when the SDK
+    exposes it, the upstream HTTP status — enough for the calling service to
+    debug the failure and react (e.g. retry on 429).
+    """
+
+    def __init__(self, message, upstream_status=None):
+        self.upstream_status = upstream_status  # int HTTP status, if known
+        super().__init__(message)
+
+
+def _upstream_status(exc):
+    """Best-effort upstream HTTP status from an SDK exception, else None.
+
+    The OpenAI SDK exposes an int ``status_code``; the google-genai SDK exposes
+    an int ``code``. Returns None when neither is a usable int.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is None and isinstance(getattr(exc, "code", None), int):
+        status = exc.code
+    return status if isinstance(status, int) else None
+
+
 class LLMService:
     """Service class for handling LLM API calls"""
 
@@ -82,7 +107,7 @@ class LLMService:
             return content.strip()
         except Exception as e:
             logger.exception("OpenAI call failed: %s", e)
-            raise
+            raise ProviderError(str(e), _upstream_status(e)) from e
 
     def call_gemini(
         self,
@@ -136,7 +161,7 @@ class LLMService:
             return text.strip()
         except Exception as e:
             logger.exception("Gemini call failed: %s", e)
-            raise
+            raise ProviderError(str(e), _upstream_status(e)) from e
 
     def generate(self, api_key, provider, model, user_text, system_prompt,
                  prompting_strategy="few_shot"):

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -90,7 +90,13 @@ class LLMService:
         return ProviderError(str(exc), _upstream_status(exc))
 
     def call_openai(
-        self, api_key, system_prompt, user_text, prompting_strategy, model="gpt-4o"
+        self,
+        api_key,
+        system_prompt,
+        user_text,
+        prompting_strategy,
+        model="gpt-4o",
+        temperature=0.0,
     ):
         """Call an OpenAI model via the Responses API with Structured Outputs.
 
@@ -106,6 +112,10 @@ class LLMService:
         left is ``temperature``: GPT-5.x / o-series reasoning models reject it,
         while ``gpt-4o`` accepts it. That capability comes from the registry
         instead of a name heuristic.
+
+        ``temperature`` defaults to ``0.0`` (deterministic). The retry loop
+        passes a small non-zero value on regeneration so a failed attempt is
+        not reproduced verbatim; it is only applied when the model accepts it.
 
         Returns ``response.output_text`` — the raw JSON string — so the calling
         service keeps receiving a string it can hand on unchanged.
@@ -127,7 +137,7 @@ class LLMService:
             "text_format": ProcessModel,
         }
         if model_registry.supports_temperature("openai", model):
-            request_params["temperature"] = 0
+            request_params["temperature"] = temperature
 
         try:
             logger.info("Calling OpenAI responses.parse (model=%s)", model)
@@ -143,6 +153,7 @@ class LLMService:
         user_text,
         prompting_strategy,
         model="gemini-3.5-flash",
+        temperature=0.0,
     ):
         """Call a Google Gemini model via the unified ``google-genai`` SDK.
 
@@ -157,6 +168,13 @@ class LLMService:
         OpenAI path uses — so Gemini is constrained to the BPMN-JSON shape and
         ``type`` values instead of relying on the prompt's hand-written rules.
         ``response.text`` is still the raw JSON string the caller hands on.
+
+        ``temperature`` defaults to ``0.0``; the retry loop passes a small
+        non-zero value on regeneration. At ``0.0`` we also pin ``top_k=1`` /
+        ``top_p=1.0`` for fully greedy, deterministic decoding. When a non-zero
+        temperature is requested those are left at the model defaults — pinning
+        ``top_k=1`` would force greedy selection regardless of temperature, so
+        keeping them would make the retry's temperature bump a no-op.
 
         ``model`` defaults to ``gemini-3.5-flash`` (the current standard flash
         tier); the v2 ``/generate`` flow passes the model selected from the
@@ -178,9 +196,12 @@ class LLMService:
             "response_schema": ProcessModel,
         }
         if model_registry.supports_temperature("gemini", model):
-            config["temperature"] = 0.0
-            config["top_k"] = 1
-            config["top_p"] = 1.0
+            config["temperature"] = temperature
+            if temperature == 0.0:
+                # Greedy decoding for a deterministic first attempt. Omitted on
+                # retries so the temperature bump can actually vary the output.
+                config["top_k"] = 1
+                config["top_p"] = 1.0
 
         request_params = {
             "model": model,
@@ -196,13 +217,17 @@ class LLMService:
             raise self._fail("gemini", e) from e
 
     def generate(self, api_key, provider, model, user_text, system_prompt,
-                 prompting_strategy="few_shot"):
+                 prompting_strategy="few_shot", temperature=0.0):
         """Provider-agnostic entry point used by the v2 ``/generate`` route.
 
         Looks up the dispatch method for ``provider`` in the registry and calls
         it with the registry-selected ``model``. Raises ``ValueError`` if the
         provider has no dispatch mapping (the route validates the pair against
         the registry first, so this is a defensive guard).
+
+        ``temperature`` is forwarded to the provider call; the retry loop raises
+        it above ``0.0`` on regeneration so a rejected attempt is not produced
+        verbatim again.
         """
         method_name = model_registry.dispatch_method(provider)
         if method_name is None:
@@ -214,4 +239,5 @@ class LLMService:
             user_text=user_text,
             prompting_strategy=prompting_strategy,
             model=model,
+            temperature=temperature,
         )

--- a/app/services/llm_service.py
+++ b/app/services/llm_service.py
@@ -10,8 +10,12 @@ from app.services import model_registry
 logger = logging.getLogger(__name__)
 
 # Upper bound on generated tokens, shared by both providers so the output budget
-# is consistent regardless of which model handles the request.
-_MAX_OUTPUT_TOKENS = 4096
+# is consistent regardless of which model handles the request. This is a ceiling,
+# not a target — callers are billed only for the tokens actually generated — so it
+# is set generously to give large process models room rather than truncating their
+# JSON. Truncation against this bound is detected and surfaced per provider below.
+# Kept within every registered model's output limit (e.g. gpt-4o caps at 16384).
+_MAX_OUTPUT_TOKENS = 8192
 
 
 class ProviderError(Exception):
@@ -142,9 +146,21 @@ class LLMService:
         try:
             logger.info("Calling OpenAI responses.parse (model=%s)", model)
             response = client.responses.parse(**request_params)
-            return self._finish("openai", response.output_text, start_time)
         except Exception as e:
             raise self._fail("openai", e) from e
+
+        # A truncated (max_output_tokens) or content-filtered response comes back
+        # with status "incomplete" and partial/empty output. Returning that
+        # partial text would hand broken JSON to the caller, so fail explicitly.
+        if getattr(response, "status", None) == "incomplete":
+            reason = getattr(
+                getattr(response, "incomplete_details", None), "reason", None
+            )
+            raise ProviderError(
+                f"OpenAI returned an incomplete response (reason={reason}); the "
+                f"model likely hit max_output_tokens={_MAX_OUTPUT_TOKENS}."
+            )
+        return self._finish("openai", response.output_text, start_time)
 
     def call_gemini(
         self,
@@ -185,10 +201,8 @@ class LLMService:
         )
         client = genai.Client(api_key=api_key)
 
-        # Gemini nests the generation settings in a `config` object (the only
-        # structural difference from OpenAI's flat params); everything else
-        # follows the same build-request_params-then-call(**request_params)
-        # pattern.
+        # Gemini nests the generation settings in a `config` object — the only
+        # structural difference from OpenAI's flat request params.
         config = {
             "system_instruction": system_prompt,
             "max_output_tokens": _MAX_OUTPUT_TOKENS,
@@ -212,9 +226,21 @@ class LLMService:
         try:
             logger.info("Calling Gemini generate_content (model=%s)", model)
             response = client.models.generate_content(**request_params)
-            return self._finish("gemini", response.text, start_time)
         except Exception as e:
             raise self._fail("gemini", e) from e
+
+        # Anything other than a clean STOP (e.g. MAX_TOKENS truncation or a
+        # SAFETY block) means the JSON is partial or absent; reading
+        # ``response.text`` would yield broken/empty output, so fail explicitly.
+        # Compared by name so a non-STOP reason surfaces regardless of SDK enum.
+        candidate = response.candidates[0] if response.candidates else None
+        finish = getattr(getattr(candidate, "finish_reason", None), "name", None)
+        if finish is not None and finish not in ("STOP", "FINISH_REASON_UNSPECIFIED"):
+            raise ProviderError(
+                f"Gemini did not finish cleanly (finish_reason={finish}); output "
+                f"may exceed max_output_tokens={_MAX_OUTPUT_TOKENS} or was blocked."
+            )
+        return self._finish("gemini", response.text, start_time)
 
     def generate(self, api_key, provider, model, user_text, system_prompt,
                  prompting_strategy="few_shot", temperature=0.0):

--- a/app/services/model_registry.py
+++ b/app/services/model_registry.py
@@ -10,7 +10,7 @@ Keeping the registry here (instead of inline in the routes) means the advertised
 list and the accepted list can never drift apart.
 """
 
-# Each entry: provider key -> list of supported model names.
+# Each entry: provider key -> {model name -> capability metadata}.
 #
 # We list the current GPT-5.x / Gemini-3.x generations, but deliberately stay on
 # the cost-effective *standard* tiers (mini / nano / flash) rather than the
@@ -18,20 +18,24 @@ list and the accepted list can never drift apart.
 # process-description workload needs. ``gpt-4o`` is the only legacy model kept,
 # purely for backward compatibility.
 #
-# NOTE: the GPT-5.x models reject ``temperature`` and ``max_tokens`` and require
-# ``max_completion_tokens`` instead; ``LLMService.call_openai`` handles that
-# parameter split, so every model below works with the live dispatch.
+# Capability metadata drives the request parameters in ``LLMService`` so we no
+# longer rely on brittle model-name prefix heuristics:
+#
+# * ``supports_temperature`` — the GPT-5.x / o-series reasoning models reject
+#   ``temperature`` (and sampling knobs); ``gpt-4o`` and the Gemini models still
+#   accept them. With the OpenAI Responses API the token-limit parameter is
+#   unified (``max_output_tokens``), so temperature is the only remaining split.
 _REGISTRY = {
-    "openai": [
-        "gpt-5.5",  # newest general-purpose standard model
-        "gpt-5.4-mini",  # cost-effective, recommended default for this workload
-        "gpt-5.4-nano",  # cheapest, high-volume / low-latency
-        "gpt-4o",  # legacy, kept for backward compatibility
-    ],
-    "gemini": [
-        "gemini-3.5-flash",  # newest flash tier, best price/performance
-        "gemini-3.1-flash-lite",  # cheapest, high-volume / low-latency
-    ],
+    "openai": {
+        "gpt-5.5": {"supports_temperature": False},  # newest general-purpose standard
+        "gpt-5.4-mini": {"supports_temperature": False},  # recommended default here
+        "gpt-5.4-nano": {"supports_temperature": False},  # cheapest, high-volume
+        "gpt-4o": {"supports_temperature": True},  # legacy, backward compatibility
+    },
+    "gemini": {
+        "gemini-3.5-flash": {"supports_temperature": True},  # best price/performance
+        "gemini-3.1-flash-lite": {"supports_temperature": True},  # cheapest
+    },
 }
 
 # Maps a provider to the LLMService method name that dispatches the call.
@@ -56,7 +60,17 @@ def list_models():
 
 def is_valid(provider, model):
     """Return True if the given provider/model pair is supported."""
-    return model in _REGISTRY.get(provider, ())
+    return model in _REGISTRY.get(provider, {})
+
+
+def supports_temperature(provider, model):
+    """Return True if the model accepts a ``temperature`` (sampling) parameter.
+
+    Reasoning models (GPT-5.x / o-series) reject it. Defaults to ``True`` for
+    unknown pairs so the classic, widely-supported behaviour is the fallback;
+    callers validate the pair against the registry first anyway.
+    """
+    return _REGISTRY.get(provider, {}).get(model, {}).get("supports_temperature", True)
 
 
 def dispatch_method(provider):

--- a/app/utils/few_shot_templates.json
+++ b/app/utils/few_shot_templates.json
@@ -23,29 +23,33 @@
         { "id": "gateway1", "type": "parallelGateway", "name": "Start Parallel Checks" },
         { "id": "gateway2", "type": "parallelGateway", "name": "Join Parallel Checks" },
         { "id": "gateway3", "type": "exclusiveGateway", "name": "Is Form Complete?" },
-        { "id": "gateway4", "type": "exclusiveGateway", "name": "Approval Decision" }
+        { "id": "gateway4", "type": "exclusiveGateway", "name": "Approval Decision" },
+        { "id": "gateway5", "type": "exclusiveGateway", "name": "Resume Verification" },
+        { "id": "gateway6", "type": "exclusiveGateway", "name": "Merge Outcome" }
       ],
       "flows": [
         { "id": "flow1", "type": "sequenceFlow", "source": "startEvent1", "target": "task1" },
         { "id": "flow2", "type": "sequenceFlow", "source": "task1", "target": "gateway1" },
         { "id": "flow3", "type": "sequenceFlow", "source": "gateway1", "target": "task2" },
-        { "id": "flow4", "type": "sequenceFlow", "source": "gateway1", "target": "task3" },
+        { "id": "flow4", "type": "sequenceFlow", "source": "gateway1", "target": "gateway5" },
         { "id": "flow5", "type": "sequenceFlow", "source": "gateway1", "target": "task4" },
-        { "id": "flow6", "type": "sequenceFlow", "source": "task3", "target": "gateway3" },
-        { "id": "flow7", "type": "sequenceFlow", "source": "gateway3", "target": "task5" },
-        { "id": "flow8", "type": "sequenceFlow", "source": "task5", "target": "task6" },
-        { "id": "flow9", "type": "sequenceFlow", "source": "task6", "target": "task3" },
-        { "id": "flow10", "type": "sequenceFlow", "source": "gateway3", "target": "gateway2" },
-        { "id": "flow11", "type": "sequenceFlow", "source": "task2", "target": "gateway2" },
-        { "id": "flow12", "type": "sequenceFlow", "source": "task4", "target": "gateway2" },
-        { "id": "flow13", "type": "sequenceFlow", "source": "gateway2", "target": "task7" },
-        { "id": "flow14", "type": "sequenceFlow", "source": "task7", "target": "gateway4" },
-        { "id": "flow15", "type": "sequenceFlow", "source": "gateway4", "target": "task8" },
-        { "id": "flow16", "type": "sequenceFlow", "source": "gateway4", "target": "task9" },
-        { "id": "flow17", "type": "sequenceFlow", "source": "task8", "target": "task10" },
-        { "id": "flow18", "type": "sequenceFlow", "source": "task9", "target": "task11" },
-        { "id": "flow19", "type": "sequenceFlow", "source": "task10", "target": "endEvent1" },
-        { "id": "flow20", "type": "sequenceFlow", "source": "task11", "target": "endEvent1" }
+        { "id": "flow6", "type": "sequenceFlow", "source": "gateway5", "target": "task3" },
+        { "id": "flow7", "type": "sequenceFlow", "source": "task3", "target": "gateway3" },
+        { "id": "flow8", "type": "sequenceFlow", "source": "gateway3", "target": "task5" },
+        { "id": "flow9", "type": "sequenceFlow", "source": "task5", "target": "task6" },
+        { "id": "flow10", "type": "sequenceFlow", "source": "task6", "target": "gateway5" },
+        { "id": "flow11", "type": "sequenceFlow", "source": "gateway3", "target": "gateway2" },
+        { "id": "flow12", "type": "sequenceFlow", "source": "task2", "target": "gateway2" },
+        { "id": "flow13", "type": "sequenceFlow", "source": "task4", "target": "gateway2" },
+        { "id": "flow14", "type": "sequenceFlow", "source": "gateway2", "target": "task7" },
+        { "id": "flow15", "type": "sequenceFlow", "source": "task7", "target": "gateway4" },
+        { "id": "flow16", "type": "sequenceFlow", "source": "gateway4", "target": "task8" },
+        { "id": "flow17", "type": "sequenceFlow", "source": "gateway4", "target": "task9" },
+        { "id": "flow18", "type": "sequenceFlow", "source": "task8", "target": "task10" },
+        { "id": "flow19", "type": "sequenceFlow", "source": "task9", "target": "task11" },
+        { "id": "flow20", "type": "sequenceFlow", "source": "task10", "target": "gateway6" },
+        { "id": "flow21", "type": "sequenceFlow", "source": "task11", "target": "gateway6" },
+        { "id": "flow22", "type": "sequenceFlow", "source": "gateway6", "target": "endEvent1" }
       ]
     }
   },
@@ -73,10 +77,11 @@
     }
   },
   {
-    "description": "Example: TwoTrafficLightsSafeFair: The system models the behavior of two traffic lights that alternate safely to ensure fairness.\nInitially, the first light is red and the second is green.\n\nWhen the green light of the second traffic light turns yellow and then red, it becomes safe for the first light to begin its transition.\nThe first traffic light changes from red to yellow and then to green, while the second light remains red.\n\nThis alternation continues to ensure that both directions have equal access to go, while never being green at the same time.\n\nThe 'safe1' and 'safe2' places act as synchronization points that enforce mutual exclusion — ensuring that only one light can be green at a time.\n\nThe process loops indefinitely to simulate real-world traffic control.",
+    "description": "Example: TwoTrafficLightsSafeFair: The system models two traffic lights that alternate safely to ensure fairness.\nInitially, the first light is red and the second is green.\n\nWhen the green light of the second traffic light turns yellow and then red, it becomes safe for the first light to begin its transition.\nThe first traffic light changes from red to yellow and then to green, while the second light remains red.\n\nThis alternation ensures that both directions get equal access to go, while the two lights are never green at the same time, enforcing mutual exclusion.\n\nAfter each full cycle the controller decides whether to keep running: it either starts the next cycle or shuts the traffic control down.",
     "bpmn": {
       "events": [
-        { "id": "startEvent1", "type": "startEvent", "name": "Start Traffic Loop" }
+        { "id": "startEvent1", "type": "startEvent", "name": "Start Traffic Loop" },
+        { "id": "endEvent1", "type": "endEvent", "name": "Traffic Control Stopped" }
       ],
       "tasks": [
         { "id": "task1", "type": "serviceTask", "name": "Switch Light 2 from Green to Yellow" },
@@ -89,19 +94,22 @@
         { "id": "task8", "type": "serviceTask", "name": "Switch Light 2 from Yellow to Green" }
       ],
       "gateways": [
-        { "id": "gateway1", "type": "exclusiveGateway", "name": "Safe to Switch?" }
+        { "id": "gateway1", "type": "exclusiveGateway", "name": "Continue Cycle?" },
+        { "id": "gateway2", "type": "exclusiveGateway", "name": "Resume Cycle" }
       ],
       "flows": [
-        { "id": "flow1", "type": "sequenceFlow", "source": "startEvent1", "target": "task1" },
-        { "id": "flow2", "type": "sequenceFlow", "source": "task1", "target": "task2" },
-        { "id": "flow3", "type": "sequenceFlow", "source": "task2", "target": "task3" },
-        { "id": "flow4", "type": "sequenceFlow", "source": "task3", "target": "task4" },
-        { "id": "flow5", "type": "sequenceFlow", "source": "task4", "target": "task5" },
-        { "id": "flow6", "type": "sequenceFlow", "source": "task5", "target": "task6" },
-        { "id": "flow7", "type": "sequenceFlow", "source": "task6", "target": "task7" },
-        { "id": "flow8", "type": "sequenceFlow", "source": "task7", "target": "task8" },
-        { "id": "flow9", "type": "sequenceFlow", "source": "task8", "target": "gateway1" },
-        { "id": "flow10", "type": "sequenceFlow", "source": "gateway1", "target": "task1" }
+        { "id": "flow1", "type": "sequenceFlow", "source": "startEvent1", "target": "gateway2" },
+        { "id": "flow2", "type": "sequenceFlow", "source": "gateway2", "target": "task1" },
+        { "id": "flow3", "type": "sequenceFlow", "source": "task1", "target": "task2" },
+        { "id": "flow4", "type": "sequenceFlow", "source": "task2", "target": "task3" },
+        { "id": "flow5", "type": "sequenceFlow", "source": "task3", "target": "task4" },
+        { "id": "flow6", "type": "sequenceFlow", "source": "task4", "target": "task5" },
+        { "id": "flow7", "type": "sequenceFlow", "source": "task5", "target": "task6" },
+        { "id": "flow8", "type": "sequenceFlow", "source": "task6", "target": "task7" },
+        { "id": "flow9", "type": "sequenceFlow", "source": "task7", "target": "task8" },
+        { "id": "flow10", "type": "sequenceFlow", "source": "task8", "target": "gateway1" },
+        { "id": "flow11", "type": "sequenceFlow", "source": "gateway1", "target": "gateway2" },
+        { "id": "flow12", "type": "sequenceFlow", "source": "gateway1", "target": "endEvent1" }
       ]
     }
   },

--- a/app/utils/prompt_builder.py
+++ b/app/utils/prompt_builder.py
@@ -33,7 +33,7 @@ class PromptBuilder:
             return "\n".join(sections)
 
         elif strategy == "zero_shot":
-            return f"Please generate a BPMN model for the following description:\n\n{user_input}\n\nBPMN:"
+            return f"Please generate the BPMN-JSON model for the following process description:\n\n{user_input}\n\nBPMN:"
 
         else:
             raise ValueError(f"Unsupported prompting strategy: {strategy}")

--- a/boot.sh
+++ b/boot.sh
@@ -1,14 +1,5 @@
 #!/bin/sh
-source venv/bin/activate
-
-# Schemamigration of flask
-# while true; do
-#     flask deploy
-#     if [[ "$?" == "0" ]]; then
-#         break
-#     fi
-#     echo Deploy command failed, retrying in 5 secs...
-#     sleep 5
-# done
+# POSIX `.` (not the bash-only `source`) since the shebang is /bin/sh.
+. venv/bin/activate
 
 exec gunicorn -b :5000 --access-logfile - --error-logfile - llm-api-connector:app

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -32,6 +32,8 @@ Body: {
 Response 200: { "raw_response": string }
 Response 400: { "error": { "code": string, "message": string } }
 Response 401: { "error": { "code": string, "message": string } }
+Response 429: { "error": { "code": string, "message": string } }
+Response 502: { "error": { "code": string, "message": string } }
 Response 500: { "error": { "code": string, "message": string } }
 ```
 
@@ -40,9 +42,10 @@ prompt, dispatches the call to the selected `provider`/`model`, and returns the 
 provider response.
 
 Error codes: `invalid_request`, `invalid_provider` (400); `unauthorized` (401);
-`upstream_error`, `internal_error` (500). A missing or malformed `Authorization`
-header returns `401 unauthorized`; a non-JSON body or a missing/empty required
-field returns `400 invalid_request`.
+`upstream_error` (429 retryable / 502 bad gateway — the `message` carries the
+provider's own error text); `internal_error` (500). A missing or malformed
+`Authorization` header returns `401 unauthorized`; a non-JSON body or a
+missing/empty required field returns `400 invalid_request`.
 
 ## `GET /models`
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -41,6 +41,10 @@ paths:
                 $ref: '#/components/schemas/GenerateResult'
         '400':
           $ref: '#/components/responses/Error'
+        '429':
+          $ref: '#/components/responses/Error'
+        '502':
+          $ref: '#/components/responses/Error'
         '500':
           $ref: '#/components/responses/Error'
 
@@ -148,8 +152,13 @@ components:
               type: string
               description: >-
                 Stable identifier. Known values: `invalid_request`,
-                `invalid_provider` (400); `upstream_error`, `internal_error` (500).
+                `invalid_provider` (400); `upstream_error` (429 retryable / 502
+                bad gateway — the `message` carries the provider's own error
+                text); `internal_error` (500).
               example: invalid_request
             message:
               type: string
+              description: >-
+                Human-readable detail. For `upstream_error` this is the raw
+                error text returned by the LLM provider.
               example: "Missing or empty field(s): provider."

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -41,6 +41,8 @@ paths:
                 $ref: '#/components/schemas/GenerateResult'
         '400':
           $ref: '#/components/responses/Error'
+        '401':
+          $ref: '#/components/responses/Error'
         '429':
           $ref: '#/components/responses/Error'
         '502':
@@ -113,7 +115,7 @@ components:
         model:
           type: string
           description: Model name; one of the values from GET /models.
-          example: gpt-4o
+          example: gpt-5.4-mini
         prompting_strategy:
           type: string
           description: Prompting strategy to use. Defaults to "few_shot" if omitted.
@@ -140,7 +142,7 @@ components:
                 example: openai
               model:
                 type: string
-                example: gpt-4o
+                example: gpt-5.4-mini
 
     Error:
       type: object
@@ -152,9 +154,9 @@ components:
               type: string
               description: >-
                 Stable identifier. Known values: `invalid_request`,
-                `invalid_provider` (400); `upstream_error` (429 retryable / 502
-                bad gateway — the `message` carries the provider's own error
-                text); `internal_error` (500).
+                `invalid_provider` (400); `unauthorized` (401); `upstream_error`
+                (429 retryable / 502 bad gateway — the `message` carries the
+                provider's own error text); `internal_error` (500).
               example: invalid_request
             message:
               type: string

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,6 +4,6 @@ flask_cors==4.0.0
 flask-swagger-ui==5.21.0
 flask-wtf==1.2.1
 openai==1.79.0
-google-generativeai==0.8.5
+google-genai==2.8.0
 prometheus_client==0.19.0
 python-json-logger==0.1.11

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,9 +1,9 @@
 coverage==7.5.1
-Flask==3.1.2
-flask_cors==4.0.0
+Flask==3.1.3
+flask_cors==6.0.5
 flask-swagger-ui==5.21.0
 flask-wtf==1.2.1
-openai==1.79.0
-google-genai==2.8.0
+openai==2.43.0
+google-genai==2.9.0
 prometheus_client==0.19.0
 python-json-logger==0.1.11

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,1 +1,1 @@
--r common.txt
+-r test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,2 @@
 -r common.txt
+pytest==9.1.1

--- a/tests/test_few_shot_templates.py
+++ b/tests/test_few_shot_templates.py
@@ -1,0 +1,34 @@
+"""Guard: every shipped few-shot example must pass the connector's own validators.
+
+Few-shot examples are the strongest signal the model imitates. If one violates
+the rules ``app.validation`` enforces (single start/end, explicit split/join
+gateways, connectivity, ...), it teaches the model to produce output the
+connector then rejects — driving wasted regenerations. This test fails loudly,
+naming the offending example, so a broken template can never ship again.
+"""
+
+import pytest
+
+from app.utils.prompt_builder import PromptBuilder
+from app.validation import ValidationError, validate_model
+
+_TEMPLATES = PromptBuilder().few_shot_templates
+
+
+def test_few_shot_templates_are_loaded():
+    # A silent load failure degrades few-shot prompting to an empty example set;
+    # guard against shipping zero templates as much as against broken ones.
+    assert _TEMPLATES, "no few-shot templates loaded"
+
+
+@pytest.mark.parametrize(
+    "example",
+    _TEMPLATES,
+    ids=[ex.get("description", "")[:40] for ex in _TEMPLATES],
+)
+def test_few_shot_example_passes_validators(example):
+    assert "bpmn" in example, "few-shot example is missing its 'bpmn' model"
+    try:
+        validate_model(example["bpmn"])
+    except ValidationError as exc:
+        pytest.fail(f"few-shot example violates the connector validators: {exc}")

--- a/tests/test_t2p_service.py
+++ b/tests/test_t2p_service.py
@@ -34,18 +34,15 @@ class TestT2PService(unittest.TestCase):
     def run_test_case(self, sentence, expected_keywords, mock_openai):
         for strategy in self.strategies:
             with self.subTest(strategy=strategy):
-                # Setup mock
-                mock_response = self.create_mock_response(
+                # Setup mock — Responses API: responses.create(...).output_text
+                response_text = self.create_mock_response(
                     sentence, expected_keywords, strategy
                 )
-                mock_choice = MagicMock()
-                mock_choice.message.content = mock_response
+                mock_response = MagicMock()
+                mock_response.output_text = response_text
 
-                mock_completion = MagicMock()
-                mock_completion.choices = [mock_choice]
-
-                mock_openai.return_value.chat.completions.create.return_value = (
-                    mock_completion
+                mock_openai.return_value.responses.create.return_value = (
+                    mock_response
                 )
 
                 # Run test

--- a/tests/test_t2p_service.py
+++ b/tests/test_t2p_service.py
@@ -34,14 +34,14 @@ class TestT2PService(unittest.TestCase):
     def run_test_case(self, sentence, expected_keywords, mock_openai):
         for strategy in self.strategies:
             with self.subTest(strategy=strategy):
-                # Setup mock — Responses API: responses.create(...).output_text
+                # Setup mock — Responses API: responses.parse(...).output_text
                 response_text = self.create_mock_response(
                     sentence, expected_keywords, strategy
                 )
                 mock_response = MagicMock()
                 mock_response.output_text = response_text
 
-                mock_openai.return_value.responses.create.return_value = (
+                mock_openai.return_value.responses.parse.return_value = (
                     mock_response
                 )
 

--- a/tests/test_t2p_service.py
+++ b/tests/test_t2p_service.py
@@ -41,9 +41,7 @@ class TestT2PService(unittest.TestCase):
                 mock_response = MagicMock()
                 mock_response.output_text = response_text
 
-                mock_openai.return_value.responses.parse.return_value = (
-                    mock_response
-                )
+                mock_openai.return_value.responses.parse.return_value = mock_response
 
                 # Run test
                 result = self.llm_service.call_openai(

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -17,18 +17,18 @@ class TestV2Api(unittest.TestCase):
 
     # --- helpers ----------------------------------------------------------
     def _mock_openai(self, mock_openai, content="RAW BPMN JSON"):
-        mock_choice = MagicMock()
-        mock_choice.message.content = content
-        mock_completion = MagicMock()
-        mock_completion.choices = [mock_choice]
-        mock_openai.return_value.chat.completions.create.return_value = mock_completion
+        # Responses API: client.responses.create(...).output_text
+        mock_response = MagicMock()
+        mock_response.output_text = content
+        mock_openai.return_value.responses.create.return_value = mock_response
 
     def _mock_gemini(self, mock_genai, content="RAW GEMINI JSON"):
+        # google-genai SDK: genai.Client(...).models.generate_content(...).text
         mock_response = MagicMock()
         mock_response.text = content
-        mock_model = MagicMock()
-        mock_model.generate_content.return_value = mock_response
-        mock_genai.GenerativeModel.return_value = mock_model
+        mock_genai.Client.return_value.models.generate_content.return_value = (
+            mock_response
+        )
 
     # --- /models ----------------------------------------------------------
     def test_models_returns_registry(self):
@@ -103,7 +103,7 @@ class TestV2Api(unittest.TestCase):
     # --- /generate upstream failure --------------------------------------
     @patch("app.services.llm_service.OpenAI")
     def test_generate_provider_error_is_500_upstream(self, mock_openai):
-        mock_openai.return_value.chat.completions.create.side_effect = RuntimeError(
+        mock_openai.return_value.responses.create.side_effect = RuntimeError(
             "boom"
         )
         response = self.client.post(
@@ -119,7 +119,7 @@ class TestV2Api(unittest.TestCase):
         # The Gemini provider must map a provider-side failure to the same
         # upstream_error 500 as OpenAI does (the OpenAI path is covered above;
         # this closes the second-provider asymmetry).
-        mock_genai.GenerativeModel.return_value.generate_content.side_effect = (
+        mock_genai.Client.return_value.models.generate_content.side_effect = (
             RuntimeError("boom")
         )
         response = self.client.post(

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -89,6 +89,26 @@ class TestV2Api(unittest.TestCase):
         # The error must not leak which check failed.
         self.assertNotIn("problem", response.get_json()["error"]["message"])
 
+    @patch("app.validation.VALIDATORS", [lambda model: ["problem"]])
+    @patch("app.api.routes._llm_service")
+    def test_generate_escalates_temperature_on_retry(self, mock_service):
+        # The first attempt must be deterministic (temperature 0); regenerations
+        # must use a non-zero temperature, otherwise the identical prompt would
+        # reproduce the identical invalid output and the retries are wasted.
+        from app.api.routes import _RETRY_TEMPERATURE
+
+        mock_service.generate.return_value = '{"events": [], "tasks": []}'
+        self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
+        )
+        temperatures = [
+            call.kwargs["temperature"]
+            for call in mock_service.generate.call_args_list
+        ]
+        self.assertEqual(temperatures, [0.0, _RETRY_TEMPERATURE, _RETRY_TEMPERATURE])
+
     @patch("app.validation.VALIDATORS", [])
     @patch("app.api.routes._llm_service")
     def test_generate_does_not_retry_when_valid(self, mock_service):

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -102,7 +102,9 @@ class TestV2Api(unittest.TestCase):
 
     # --- /generate upstream failure --------------------------------------
     @patch("app.services.llm_service.OpenAI")
-    def test_generate_provider_error_is_500_upstream(self, mock_openai):
+    def test_generate_provider_error_is_502_upstream(self, mock_openai):
+        # A provider error with no recognisable status maps to 502, and the
+        # real upstream error text is passed through as the message.
         mock_openai.return_value.responses.create.side_effect = RuntimeError(
             "boom"
         )
@@ -111,13 +113,15 @@ class TestV2Api(unittest.TestCase):
             headers={"Authorization": "Bearer secret-token"},
             json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
         )
-        self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.get_json()["error"]["code"], "upstream_error")
+        self.assertEqual(response.status_code, 502)
+        error = response.get_json()["error"]
+        self.assertEqual(error["code"], "upstream_error")
+        self.assertEqual(error["message"], "boom")
 
     @patch("app.services.llm_service.genai")
-    def test_generate_gemini_provider_error_is_500_upstream(self, mock_genai):
+    def test_generate_gemini_provider_error_is_502_upstream(self, mock_genai):
         # The Gemini provider must map a provider-side failure to the same
-        # upstream_error 500 as OpenAI does (the OpenAI path is covered above;
+        # upstream_error 502 as OpenAI does (the OpenAI path is covered above;
         # this closes the second-provider asymmetry).
         mock_genai.Client.return_value.models.generate_content.side_effect = (
             RuntimeError("boom")
@@ -131,8 +135,27 @@ class TestV2Api(unittest.TestCase):
                 "model": "gemini-3.5-flash",
             },
         )
-        self.assertEqual(response.status_code, 500)
-        self.assertEqual(response.get_json()["error"]["code"], "upstream_error")
+        self.assertEqual(response.status_code, 502)
+        error = response.get_json()["error"]
+        self.assertEqual(error["code"], "upstream_error")
+        self.assertEqual(error["message"], "boom")
+
+    @patch("app.services.llm_service.OpenAI")
+    def test_generate_rate_limit_is_passed_through_as_429(self, mock_openai):
+        # A 429 from the provider is retryable, so the connector mirrors it
+        # instead of collapsing it to 502.
+        exc = RuntimeError("rate limited")
+        exc.status_code = 429
+        mock_openai.return_value.responses.create.side_effect = exc
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
+        )
+        self.assertEqual(response.status_code, 429)
+        error = response.get_json()["error"]
+        self.assertEqual(error["code"], "upstream_error")
+        self.assertEqual(error["message"], "rate limited")
 
     # --- /generate malformed body ----------------------------------------
     def test_generate_non_json_body_is_400(self):

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -108,8 +108,7 @@ class TestV2Api(unittest.TestCase):
             json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
         )
         temperatures = [
-            call.kwargs["temperature"]
-            for call in mock_service.generate.call_args_list
+            call.kwargs["temperature"] for call in mock_service.generate.call_args_list
         ]
         self.assertEqual(temperatures, [0.0, _RETRY_TEMPERATURE, _RETRY_TEMPERATURE])
 

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -20,12 +20,16 @@ class TestV2Api(unittest.TestCase):
         # Responses API: client.responses.parse(...).output_text
         mock_response = MagicMock()
         mock_response.output_text = content
+        mock_response.status = "completed"  # not truncated/incomplete
         mock_openai.return_value.responses.parse.return_value = mock_response
 
     def _mock_gemini(self, mock_genai, content="RAW GEMINI JSON"):
         # google-genai SDK: genai.Client(...).models.generate_content(...).text
         mock_response = MagicMock()
         mock_response.text = content
+        candidate = MagicMock()
+        candidate.finish_reason.name = "STOP"  # finished cleanly
+        mock_response.candidates = [candidate]
         mock_genai.Client.return_value.models.generate_content.return_value = (
             mock_response
         )
@@ -202,6 +206,49 @@ class TestV2Api(unittest.TestCase):
         error = response.get_json()["error"]
         self.assertEqual(error["code"], "upstream_error")
         self.assertEqual(error["message"], "rate limited")
+
+    # --- /generate truncation / abnormal finish --------------------------
+    @patch("app.services.llm_service.OpenAI")
+    def test_generate_openai_incomplete_is_502(self, mock_openai):
+        # A response truncated at max_output_tokens comes back as "incomplete"
+        # with partial output; it must surface as an upstream error, not be
+        # passed through as if it were a valid model.
+        mock_response = MagicMock()
+        mock_response.status = "incomplete"
+        mock_response.incomplete_details.reason = "max_output_tokens"
+        mock_response.output_text = '{"events": [{"id": "startEv'  # partial JSON
+        mock_openai.return_value.responses.parse.return_value = mock_response
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "x", "provider": "openai", "model": "gpt-4o"},
+        )
+        self.assertEqual(response.status_code, 502)
+        error = response.get_json()["error"]
+        self.assertEqual(error["code"], "upstream_error")
+        self.assertIn("max_output_tokens", error["message"])
+
+    @patch("app.services.llm_service.genai")
+    def test_generate_gemini_max_tokens_is_502(self, mock_genai):
+        # Gemini truncation surfaces as finish_reason=MAX_TOKENS; reading .text
+        # would yield broken JSON, so it must fail as an upstream error.
+        mock_response = MagicMock()
+        mock_response.text = '{"events": [{"id": "startEv'  # partial JSON
+        candidate = MagicMock()
+        candidate.finish_reason.name = "MAX_TOKENS"
+        mock_response.candidates = [candidate]
+        mock_genai.Client.return_value.models.generate_content.return_value = (
+            mock_response
+        )
+        response = self.client.post(
+            "/generate",
+            headers={"Authorization": "Bearer secret-token"},
+            json={"user_text": "x", "provider": "gemini", "model": "gemini-3.5-flash"},
+        )
+        self.assertEqual(response.status_code, 502)
+        error = response.get_json()["error"]
+        self.assertEqual(error["code"], "upstream_error")
+        self.assertIn("MAX_TOKENS", error["message"])
 
     # --- /generate malformed body ----------------------------------------
     def test_generate_non_json_body_is_400(self):

--- a/tests/test_v2_api.py
+++ b/tests/test_v2_api.py
@@ -17,10 +17,10 @@ class TestV2Api(unittest.TestCase):
 
     # --- helpers ----------------------------------------------------------
     def _mock_openai(self, mock_openai, content="RAW BPMN JSON"):
-        # Responses API: client.responses.create(...).output_text
+        # Responses API: client.responses.parse(...).output_text
         mock_response = MagicMock()
         mock_response.output_text = content
-        mock_openai.return_value.responses.create.return_value = mock_response
+        mock_openai.return_value.responses.parse.return_value = mock_response
 
     def _mock_gemini(self, mock_genai, content="RAW GEMINI JSON"):
         # google-genai SDK: genai.Client(...).models.generate_content(...).text
@@ -133,7 +133,7 @@ class TestV2Api(unittest.TestCase):
     def test_generate_provider_error_is_502_upstream(self, mock_openai):
         # A provider error with no recognisable status maps to 502, and the
         # real upstream error text is passed through as the message.
-        mock_openai.return_value.responses.create.side_effect = RuntimeError("boom")
+        mock_openai.return_value.responses.parse.side_effect = RuntimeError("boom")
         response = self.client.post(
             "/generate",
             headers={"Authorization": "Bearer secret-token"},
@@ -172,7 +172,7 @@ class TestV2Api(unittest.TestCase):
         # instead of collapsing it to 502.
         exc = RuntimeError("rate limited")
         exc.status_code = 429
-        mock_openai.return_value.responses.create.side_effect = exc
+        mock_openai.return_value.responses.parse.side_effect = exc
         response = self.client.post(
             "/generate",
             headers={"Authorization": "Bearer secret-token"},

--- a/version.py
+++ b/version.py
@@ -12,11 +12,6 @@ __license__ = "See LICENSE file"
 __build_date__ = None
 __git_commit__ = None
 
-# Legacy: __api_version__ was intended as a URL prefix (e.g. /v1/...) but was
-# never imported or used anywhere in the codebase. Routes have no /v1 prefix
-# and get_version_info() is never called. Kept here for reference only.
-# __api_version__ = "v1"
-
 
 def get_version_info():
     """
@@ -28,7 +23,6 @@ def get_version_info():
         "description": __description__,
         "author": __author__,
         "license": __license__,
-        # "api_version": __api_version__,  # legacy, see comment above
         "build_date": __build_date__,
         "git_commit": __git_commit__,
     }

--- a/version.py
+++ b/version.py
@@ -4,7 +4,7 @@ Version and metadata information for the LLM API Connector service.
 
 __version__ = "1.4.0"
 __service_name__ = "LLM API Connector"
-__description__ = "Service for interfacing with LLM providers (OpenAI, Azure, etc.)"
+__description__ = "Service for interfacing with LLM providers (OpenAI, Google Gemini)"
 __author__ = "WoPeD Team"
 __license__ = "See LICENSE file"
 


### PR DESCRIPTION
Targets `feature/WWI23B4_T2P`. Bundles the provider modernization and the
structured-output / hardening / tooling work from `feature/prompt_optimization`.
(The validators and system-prompt rules are already on the base branch, so they
are not part of this diff.)

## Provider / API layer
- Modernize clients: OpenAI **Responses API** + unified **google-genai**
  (per-call client, no global mutable state).
- Enforce **native structured output** on both providers from one shared
  Pydantic `ProcessModel` — guarantees valid JSON and the allowed element/flow
  `type` values, replacing the prompt's hand-written "only return JSON" rules.
- Surface **truncated/aborted** responses (OpenAI `incomplete`, Gemini non-STOP
  finish) instead of returning partial JSON; raise the output ceiling to 8192.
- Pass **upstream provider errors** through `/generate` with mirrored status
  (429 retryable / 502 bad gateway).
- **Bump temperature on regeneration** so deterministic retries are not wasted
  (Gemini: drop top_k=1/top_p=1.0 on retries so the bump actually varies output).
- Symmetrize the two provider call methods around shared helpers.

## Model registry
- Default model aligned to the recommended **gpt-5.4-mini**.

## Few-shot examples
- Fix every few-shot example to pass the connector's validators (two were
  invalid: an implicit join into the end event, and an end-less infinite loop)
  and add a guard test so a broken template can never ship again.

## Dependencies / tooling / docs
- Upgrade **openai, google-genai, Flask, flask-cors** (clears known CVEs).
- **Standardize tests on pytest** so the validator suite actually runs in CI —
  `flask test` went from 25 to 47 collected tests.
- **Configure logging once** (the app emitted every line twice: plain + JSON).
- Add **ruff check** to pre-commit, clear lint findings, make boot.sh POSIX-clean.
- Align **openapi.yaml / api-contract.md / version.py** with the implementation
  (401 response, upstream_error status, provider name, model examples).

## Test status
Full suite green (47 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
